### PR TITLE
Move vite to devDependencies in frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,8 +14,7 @@
                 "@vitejs/plugin-react": "^4.2.1",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
-                "react-router-dom": "^6.20.1",
-                "vite": "^5.4.0"
+                "react-router-dom": "^6.20.1"
             },
             "devDependencies": {
                 "@types/node": "^22.15.29",
@@ -23,7 +22,7 @@
                 "@types/react-dom": "^19.1.5",
                 "i": "^0.3.7",
                 "typescript": "^5.0.0",
-                "vite": "^5.0.0"
+                "vite": "^5.4.0"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.20.1",
-        "vite": "^5.4.0"
+        "react-router-dom": "^6.20.1"
     },
     "devDependencies": {
         "@types/node": "^22.15.29",
@@ -23,6 +22,6 @@
         "@types/react-dom": "^19.1.5",
         "i": "^0.3.7",
         "typescript": "^5.0.0",
-        "vite": "^5.0.0"
+        "vite": "^5.4.0"
     }
 }


### PR DESCRIPTION
## Summary
- remove `vite` from runtime dependencies in `frontend/package.json`
- keep `vite` only under `devDependencies` with version `^5.4.0`
- sync `package-lock.json` with manual changes

## Testing
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6872cf6b96e08322b323bc03b6460c7a