### PR TITLE
Fix build path alias

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,8 +13,7 @@
                 "dotenv": "^16.3.1",
                 "drizzle-orm": "^0.44.1",
                 "express": "^4.18.2",
-                "mysql2": "^3.0.0",
-                "vitest": "^3.2.4"
+                "mysql2": "^3.0.0"
             },
             "devDependencies": {
                 "@tanstack/react-query-devtools": "^5.79.0",
@@ -24,7 +23,8 @@
                 "rimraf": "^6.0.1",
                 "ts-node": "^10.9.2",
                 "ts-node-dev": "^2.0.0",
-                "typescript": "^5.0.0"
+                "typescript": "^5.0.0",
+                "vitest": "^3.2.4"
             }
         },
         "node_modules/@cspotcode/source-map-support": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,8 +19,7 @@
         "dotenv": "^16.3.1",
         "drizzle-orm": "^0.44.1",
         "express": "^4.18.2",
-        "mysql2": "^3.0.0",
-        "vitest": "^3.2.4"
+        "mysql2": "^3.0.0"
     },
     "devDependencies": {
         "@tanstack/react-query-devtools": "^5.79.0",
@@ -30,6 +29,7 @@
         "rimraf": "^6.0.1",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "vitest": "^3.2.4"
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,8 @@
                 "@types/react-dom": "^19.1.5",
                 "i": "^0.3.7",
                 "typescript": "^5.0.0",
-                "vite": "^5.4.0"
+                "vite": "^5.4.0",
+                "vite-tsconfig-paths": "^4.2.0"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
         "@types/react-dom": "^19.1.5",
         "i": "^0.3.7",
         "typescript": "^5.0.0",
-        "vite": "^5.4.0"
+        "vite": "^5.4.0",
+        "vite-tsconfig-paths": "^4.2.0"
     }
 }

--- a/frontend/src/RegForm.tsx
+++ b/frontend/src/RegForm.tsx
@@ -1,6 +1,6 @@
 // frontend/src/RegForm.tsx
 import React, {useEffect, useState} from 'react';
-import {RegistrationForm} from './features/registration/RegistrationForm';
+import RegistrationForm from './features/registration/RegistrationForm';
 
 const RegForm = () => {
     const [fields, setFields] = useState([]);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,13 +1,14 @@
 // frontend/vite.config.ts
 import {defineConfig, loadEnv} from 'vite';
 import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig(({mode}) => {
     const env = loadEnv(mode, process.cwd(), '');
 
     return {
         root: '.', // implicit
-        plugins: [react()],
+        plugins: [react(), tsconfigPaths()],
         server: {
             host: true,
             port: parseInt(env.UI_PORT) || 3000,


### PR DESCRIPTION
## Summary
- resolve tsconfig paths in Vite build
- fix incorrect RegistrationForm import
- move vitest to devDependencies
- remove unused form-data.json

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d280d788832294268ab2c7d62f0c