### PR TITLE
Integrate shadcn ui

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
         "@vitejs/plugin-react": "^4.2.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.20.1"
+        "react-router-dom": "^6.20.1",
+        "shadcn-ui": "^0.1.0"
     },
     "devDependencies": {
         "@types/node": "^22.15.29",

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { cn } from './utils';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Button.displayName = 'Button';

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { cn } from './utils';
+
+export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      type="checkbox"
+      ref={ref}
+      className={cn(
+        'h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Checkbox.displayName = 'Checkbox';

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,0 +1,4 @@
+export * from './input';
+export * from './button';
+export * from './label';
+export * from './checkbox';

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { cn } from './utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-gray-300 px-3 py-2 text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { cn } from './utils';
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn('text-sm font-medium text-gray-700', className)}
+      {...props}
+    />
+  )
+);
+Label.displayName = 'Label';

--- a/frontend/src/components/ui/utils.ts
+++ b/frontend/src/components/ui/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | false | null | undefined)[]): string {
+  return classes.filter(Boolean).join(' ');
+}

--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -2,6 +2,10 @@
 import React, { useReducer } from 'react';
 import { FormField } from '@/data/formData';
 import { formReducer, initialFormState } from './formReducer';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
 
 type RegistrationFormProps = {
     fields: FormField[];
@@ -32,42 +36,32 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ fields }) => {
     };
 
     return (
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} className="space-y-4">
             {fields.map((field) => (
-                <div key={field.name} className="mb-4">
-                    <label htmlFor={field.name} className="block font-medium">
-                        {field.label}
-                    </label>
-
-                    <input
-                        id={field.name}
-                        name={field.name}
-                        type={field.type}
-                        value={
-                            field.type === 'checkbox'
-                                ? undefined
-                                : (state[field.name] as string | number)
-                        }
-                        checked={
-                            field.type === 'checkbox'
-                                ? (state[field.name] as boolean)
-                                : undefined
-                        }
-                        required={field.required}
-                        onChange={handleChange}
-                        className={`mt-1 block w-full rounded border px-2 py-1 ${
-                            field.type === 'checkbox' ? '' : ''
-                        }`}
-                    />
+                <div key={field.name} className="flex flex-col gap-1">
+                    <Label htmlFor={field.name}>{field.label}</Label>
+                    {field.type === 'checkbox' ? (
+                        <Checkbox
+                            id={field.name}
+                            name={field.name}
+                            checked={state[field.name] as boolean}
+                            onChange={handleChange}
+                            required={field.required}
+                        />
+                    ) : (
+                        <Input
+                            id={field.name}
+                            name={field.name}
+                            type={field.type}
+                            value={state[field.name] as string | number}
+                            onChange={handleChange}
+                            required={field.required}
+                        />
+                    )}
                 </div>
             ))}
 
-            <button
-                type="submit"
-                className="px-4 py-2 rounded bg-blue-600 text-white"
-            >
-                Register
-            </button>
+            <Button type="submit">Register</Button>
         </form>
     );
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,9 @@
+body {
+  font-family: sans-serif;
+  padding: 2rem;
+}
+
+form {
+  max-width: 400px;
+  margin: 0 auto;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './lib/queryClient';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import './index.css';
 
 const rootEl = document.getElementById('root');
 if (!rootEl) throw new Error('Root element with id="root" not found');


### PR DESCRIPTION
## Summary
- install shadcn-ui and add new UI components
- style registration form using shadcn style controls
- include a basic stylesheet and import it in the app

## Testing
- `npm run build` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e6983100832280f9d0acd89070a3