### PR TITLE
Add Section field support

### DIFF
--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -2,3 +2,4 @@ export * from './input';
 export * from './button';
 export * from './label';
 export * from './checkbox';
+export * from './section';

--- a/frontend/src/components/ui/section.tsx
+++ b/frontend/src/components/ui/section.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { cn } from './utils';
+
+export interface SectionProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Section = React.forwardRef<HTMLDivElement, SectionProps>(
+  ({ className, children, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('text-lg font-semibold mt-4', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+);
+Section.displayName = 'Section';

--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Section } from '@/components/ui/section';
 
 type RegistrationFormProps = {
     fields: FormField[];
@@ -37,33 +38,40 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ fields }) => {
 
     return (
         <form onSubmit={handleSubmit} className="space-y-4">
-            {fields.map((field) => (
-                <div key={field.name} className="flex flex-col gap-1">
-                    <Label htmlFor={field.name}>{field.label}</Label>
-                    {field.type === 'checkbox' ? (
-                        <Checkbox
-                            id={field.name}
-                            name={field.name}
-                            checked={state[field.name] as boolean}
-                            onChange={handleChange}
-                            required={field.required}
-                        />
-                    ) : (
-                        <Input
-                            id={field.name}
-                            name={field.name}
-                            type={field.type}
-                            value={state[field.name] as string | number}
-                            onChange={handleChange}
-                            required={field.required}
-                        />
-                    )}
-                </div>
-            ))}
+            {fields.map((field, index) => {
+                if (field.type === 'section') {
+                    return (
+                        <Section key={index}>{field.label}</Section>
+                    );
+                }
+                return (
+                    <div key={field.name} className="flex flex-col gap-1">
+                        <Label htmlFor={field.name}>{field.label}</Label>
+                        {field.type === 'checkbox' ? (
+                            <Checkbox
+                                id={field.name}
+                                name={field.name}
+                                checked={state[field.name] as boolean}
+                                onChange={handleChange}
+                                required={field.required}
+                            />
+                        ) : (
+                            <Input
+                                id={field.name}
+                                name={field.name}
+                                type={field.type}
+                                value={state[field.name] as string | number}
+                                onChange={handleChange}
+                                required={field.required}
+                            />
+                        )}
+                    </div>
+                );
+            })}
 
             <Button type="submit">Register</Button>
         </form>
     );
-};
+}; 
 
 export default RegistrationForm;


### PR DESCRIPTION
## Summary
- implement new `Section` component for form sections
- export Section from the UI library
- update registration form to render section titles

## Testing
- `npm test --silent` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6872efcff7bc8322923178dea7473e94