### PR TITLE
Implement registration submission

### DIFF
--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -88,7 +88,24 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ fields, initialData
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        // TODO: Submit form data
+        try {
+            const res = await fetch('/api/registrations', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(state),
+            });
+
+            if (res.ok) {
+                alert('Registration saved');
+                dispatch({ type: 'RESET', initialState: initialFormState(fields) });
+            } else {
+                const data = await res.json().catch(() => ({}));
+                alert(data.error || 'Failed to save registration');
+            }
+        } catch (err) {
+            console.error('Registration submission failed', err);
+            alert('Failed to submit registration');
+        }
     };
 
     return (


### PR DESCRIPTION
## Summary
- wire up the registration form to POST data to the backend

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687daab0c4708322953595012c11b1ac