### PR TITLE
Update registration to use credentials table

### DIFF
--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -76,9 +76,10 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ fields, initialData
                         <Input
                             id={field.name}
                             name={field.name}
-                            type={field.type}
+                            type={field.type === 'pin' ? 'text' : field.type}
                             value={state[field.name] as string | number}
                             onChange={handleChange}
+                            readOnly={field.type === 'pin'}
                             required={field.required ?? false}
                         />
                     </div>


### PR DESCRIPTION
## Summary
- display login pin as read only in RegistrationForm
- create credentials record when saving a registration
- update login and fetch routes to join credentials and include login pin

## Testing
- `npm --prefix backend run typecheck` *(fails: Cannot find type definition file for packages)*

------
https://chatgpt.com/codex/tasks/task_e_688583c12c288322ac4a912a792c3f6b