### PR TITLE
feat: hide id field unless loaded

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,8 @@ import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import registrationRoutes from './routes/registration';
+import {db} from './db/client';
+import {sql} from 'drizzle-orm';
 
 dotenv.config();
 
@@ -14,6 +16,16 @@ app.use(express.json());
 
 app.use('/api/registrations', registrationRoutes);
 
-app.listen(port, () => {
-    console.log(`Server running on port ${port}`);
-});
+async function start() {
+    try {
+        await db.execute(sql`ALTER TABLE registrations AUTO_INCREMENT = 100`);
+    } catch (err) {
+        console.error('Failed to ensure registration id start value', err);
+    }
+
+    app.listen(port, () => {
+        console.log(`Server running on port ${port}`);
+    });
+}
+
+start();

--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -21,9 +21,13 @@ type RegistrationFormProps = {
 };
 
 const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}) => {
+    const visibleFields = initialData?.id
+        ? fields
+        : fields.filter((f) => f.name !== 'id');
+
     const [state, dispatch] = useReducer(
         formReducer,
-        {...initialFormState(fields), ...(initialData || {})}
+        {...initialFormState(visibleFields), ...(initialData || {})}
     );
 
     useEffect(() => {
@@ -86,7 +90,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}
                             type={field.type === 'pin' ? 'text' : field.type}
                             value={state[field.name] as string | number}
                             onChange={handleChange}
-                            readOnly={field.type === 'pin'}
+                            readOnly={field.type === 'pin' || field.name === 'id'}
                             required={field.required ?? false}
                         />
                     </div>
@@ -97,7 +101,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         try {
-            const {loginPin: _pin, ...payload} = state;
+            const {loginPin: _pin, id: _id, ...payload} = state;
             const res = await fetch('/api/registrations', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
@@ -136,7 +140,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}
                 </header>
 
 
-                {fields.map(renderField)}
+                {visibleFields.map(renderField)}
 
                 <Button type="submit">Register</Button>
             </form>


### PR DESCRIPTION
## Summary
- ensure registration IDs start at 100 on server start
- hide form ID unless existing record is loaded and omit it from submission
- remove special handling for numeric defaults

## Testing
- `npx vitest run src/tests/route-test.ts` *(fails: No test files found)*
- `npm run build` *(backend: TS6059: File '/workspace/ConferenceRegApp/backend/test/test-drizzle.ts' is not under 'rootDir')*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_688ebe07b8c88322a32bd6c960b0aecf