### PR TITLE
Add required field validation and feedback to registration form

### DIFF
--- a/frontend/src/data/registrationFormData.ts
+++ b/frontend/src/data/registrationFormData.ts
@@ -120,8 +120,8 @@ export const registrationFormData: FormField[] = [
     {
         name: 'proxyEmail',
         label: 'Email Address',
-        type: 'phone',
-        required: false,
+        type: 'email',
+        required: true,
         scope: 'registration',
     },
     {


### PR DESCRIPTION
## Summary
- enforce proxy email as a required email field
- validate registration form client side and highlight missing inputs
- show success or error messages and switch to update mode after save

## Testing
- `npm run build` (frontend)
- `npm test` (backend, fails: ReferenceError: describe is not defined)


------
https://chatgpt.com/codex/tasks/task_e_688ece38c97c83228e4cdbfdabdb0d34