### PR TITLE
feat: restrict admin fields by role

### DIFF
--- a/frontend/src/data/registrationFormData.ts
+++ b/frontend/src/data/registrationFormData.ts
@@ -8,6 +8,7 @@ export interface FormField {
     type: 'text' | 'email' | 'phone' | 'checkbox' | 'number' | 'section' | 'pin';
     required: boolean;
     scope: 'admin' | 'registration';
+    role?: 'update';
 }
 
 // Export a typed constant for each input field.
@@ -179,6 +180,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        role: 'update',
     },
     {
         name: 'isOrganizer',
@@ -186,6 +188,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        role: 'update',
     },
     {
         name: 'isPresenter',
@@ -193,6 +196,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        role: 'update',
     },
     {
         name: 'isSponsor',
@@ -200,5 +204,6 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        role: 'update',
     },
 ];

--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -5,7 +5,7 @@ import {Link} from 'react-router-dom';
 import {ArrowLeft} from 'lucide-react';
 import {FormField} from '@/data/registrationFormData';
 import {formReducer, initialFormState} from './formReducer';
-import {generatePin} from '@/features/registration/utils';
+import {generatePin, hasRole} from '@/features/registration/utils';
 import {Input} from '@/components/ui/input';
 import {Button} from '@/components/ui/button';
 import {Label} from '@/components/ui/label';
@@ -26,13 +26,24 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}
     const [missing, setMissing] = useState<string[]>([]);
     const [message, setMessage] = useState<{text: string; type: 'success' | 'error' | ''}>({text: '', type: ''});
 
+    const hasUpdateRole = hasRole(fields, initialData, 'update');
+    const allowedFields = fields.filter(
+        (f) => f.scope !== 'admin' || hasUpdateRole
+    );
     const visibleFields = showId
-        ? fields
-        : fields.filter((f) => f.name !== 'id');
+        ? allowedFields
+        : allowedFields.filter((f) => f.name !== 'id');
+
+    const visibleFieldNames = new Set(visibleFields.map((f) => f.name));
+    const filteredInitialData = Object.fromEntries(
+        Object.entries(initialData || {}).filter(([name]) =>
+            visibleFieldNames.has(name)
+        )
+    );
 
     const [state, dispatch] = useReducer(
         formReducer,
-        {...initialFormState(visibleFields), ...(initialData || {})}
+        {...initialFormState(visibleFields), ...filteredInitialData}
     );
 
     useEffect(() => {

--- a/frontend/src/features/registration/utils.ts
+++ b/frontend/src/features/registration/utils.ts
@@ -1,6 +1,8 @@
 // frontend/src/features/registration/utils.ts
 //
 
+import {FormField} from '@/data/registrationFormData';
+
 // Generate a random Pin for a new registration user.
 export function generatePin(length: number): string {
     let pin = '';
@@ -8,4 +10,15 @@ export function generatePin(length: number): string {
         pin += Math.floor(Math.random() * 10).toString();
     }
     return pin;
+}
+
+// Determine whether the provided form data grants the user the given role.
+export function hasRole(
+    fields: FormField[],
+    data: Record<string, any> | undefined,
+    role: 'update'
+): boolean {
+    return fields
+        .filter((f) => f.role === role)
+        .some((f) => Boolean(data?.[f.name]));
 }


### PR DESCRIPTION
## Summary
- add role metadata to form fields and mark admin roles
- filter registration form fields by user role with helper

## Testing
- `npm test` *(fails: ReferenceError: describe is not defined)*
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_688eea15e74c8322ba7ea6b451e9c045