### PR TITLE
Hide admin fields unless user has update privilege

### DIFF
--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -1,6 +1,6 @@
 // frontend/src/features/registration/RegistrationForm.tsx
 
-import React, {useEffect, useReducer, useState} from 'react';
+import React, {useEffect, useMemo, useReducer, useState} from 'react';
 import {Link} from 'react-router-dom';
 import {ArrowLeft} from 'lucide-react';
 import {FormField} from '@/data/registrationFormData';
@@ -22,13 +22,28 @@ type RegistrationFormProps = {
 
 const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}) => {
     const [showId, setShowId] = useState(Boolean(initialData?.id));
+
+    const hasUpdatePrivilege = useMemo(
+        () =>
+            fields
+                .filter((f) => f.priv === 'update')
+                .some((f) => Boolean(initialData?.[f.name])),
+        [fields, initialData]
+    );
+
     const [isSaved, setIsSaved] = useState(Boolean(initialData?.id));
     const [missing, setMissing] = useState<string[]>([]);
     const [message, setMessage] = useState<{text: string; type: 'success' | 'error' | ''}>({text: '', type: ''});
 
-    const visibleFields = showId
-        ? fields
-        : fields.filter((f) => f.name !== 'id');
+    const visibleFields = useMemo(
+        () =>
+            fields.filter((f) => {
+                if (!showId && f.name === 'id') return false;
+                if (f.scope === 'admin' && !hasUpdatePrivilege) return false;
+                return true;
+            }),
+        [fields, showId, hasUpdatePrivilege]
+    );
 
     const [state, dispatch] = useReducer(
         formReducer,


### PR DESCRIPTION
## Summary
- Ensure admin-scoped registration fields only render for users with update privileges
- Centralize visible field filtering using memoized checks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ef604dbc8832291b3e57b32e9ab37