### PR TITLE
feat: extract reusable message component

### DIFF
--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -3,3 +3,4 @@ export * from './button';
 export * from './label';
 export * from './checkbox';
 export * from './section';
+export * from './message';

--- a/frontend/src/components/ui/message.tsx
+++ b/frontend/src/components/ui/message.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { cn } from './utils';
+
+export interface MessageProps {
+    text: string;
+    isError?: boolean;
+}
+
+export const Message: React.FC<MessageProps> = ({ text, isError = false }) => (
+    <div
+        className={cn(
+            'border border-input rounded-md px-4 py-2',
+            isError ? 'bg-red-100' : 'bg-green-100'
+        )}
+    >
+        {text}
+    </div>
+);
+
+Message.displayName = 'Message';
+

--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -11,6 +11,7 @@ import {Button} from '@/components/ui/button';
 import {Label} from '@/components/ui/label';
 import {Checkbox} from '@/components/ui/checkbox-wrapper';
 import {Section} from '@/components/ui/section';
+import {Message} from '@/components/ui/message';
 import AppLayout from '@/components/layout/AppLayout';
 
 const PAGE_TITLE = 'Conference Registration';
@@ -216,15 +217,10 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}
                         {isSaved ? 'Update Registration' : 'Register'}
                     </Button>
                     {message.text && (
-                        <div
-                            className={`border border-input rounded-md px-4 py-2 ${
-                                message.type === 'error'
-                                    ? 'bg-yellow-100'
-                                    : 'bg-green-100'
-                            }`}
-                        >
-                            {message.text}
-                        </div>
+                        <Message
+                            text={message.text}
+                            isError={message.type === 'error'}
+                        />
                     )}
                 </div>
             </form>


### PR DESCRIPTION
## Summary
- add `Message` UI component for success and error states
- use `Message` component in RegistrationForm

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fdc92ad808322866006b95043dc53