### PR TITLE
refactor: split form fields into input and section types

### DIFF
--- a/frontend/src/data/registrationFormData.ts
+++ b/frontend/src/data/registrationFormData.ts
@@ -10,21 +10,29 @@
 //    scope         The scope determines when it will get displayed
 //
 // Defining a form input field:
-//    field         The field name, see backend/src/db/schema.ts
+//    name          The field name, see backend/src/db/schema.ts
 //    label         Input prompt text
 //    type          Input type
-//    required      Optional, set to true if needed
+//    required      Set to true if needed
 //    scope         The scope determines when it will get displayed
 //    priv          Flag a field as being a privileged role
-//
-export interface FormField {
-    name?: string;
+
+export interface FormSectionHeading {
     label: string;
-    type: 'text' | 'email' | 'phone' | 'checkbox' | 'number' | 'section' | 'pin';
-    required?: boolean;
+    type: 'section';
     scope: 'admin' | 'registration';
-    priv?: 'update';
 }
+
+export interface FormInputField {
+    name: string;
+    label: string;
+    type: 'text' | 'email' | 'phone' | 'checkbox' | 'number' | 'pin';
+    required: boolean;
+    scope: 'admin' | 'registration';
+    priv: 'update' | null;
+}
+
+export type FormField = FormSectionHeading | FormInputField;
 
 // Export a typed constant for each form element type.
 export const registrationFormData: FormField[] = [
@@ -32,7 +40,9 @@ export const registrationFormData: FormField[] = [
         name: 'id',
         label: 'Registration Form ID',
         type: 'number',
+        required: false,
         scope: 'admin',
+        priv: null,
     },
     {
         label: 'You will be able to use your email address and the provided Pin if you need to update your registration information.',
@@ -45,6 +55,7 @@ export const registrationFormData: FormField[] = [
         type: 'email',
         required: true,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'loginPin',
@@ -52,6 +63,7 @@ export const registrationFormData: FormField[] = [
         type: 'pin',
         required: true,
         scope: 'registration',
+        priv: null,
     },
     {
         label: 'Provide your (attendee) contact information.',
@@ -64,6 +76,7 @@ export const registrationFormData: FormField[] = [
         type: 'phone',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'phone2',
@@ -71,6 +84,7 @@ export const registrationFormData: FormField[] = [
         type: 'phone',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'firstName',
@@ -78,6 +92,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'lastName',
@@ -85,6 +100,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: true,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'namePrefix',
@@ -92,6 +108,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'nameSuffix',
@@ -99,6 +116,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'day1Attendee',
@@ -106,6 +124,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'day2Attendee',
@@ -113,6 +132,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'question1',
@@ -120,6 +140,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: true,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'question2',
@@ -127,6 +148,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: true,
         scope: 'registration',
+        priv: null,
     },
     {
         label: 'If you need to cancel, please let us know.',
@@ -139,11 +161,11 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         label: 'If you are registering another person, please provide your contact information.',
         type: 'section',
-        required: false,
         scope: 'registration',
     },
     {
@@ -152,6 +174,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'proxyName',
@@ -159,6 +182,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'proxyPhone',
@@ -166,6 +190,7 @@ export const registrationFormData: FormField[] = [
         type: 'phone',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         name: 'proxyEmail',
@@ -173,6 +198,7 @@ export const registrationFormData: FormField[] = [
         type: 'email',
         required: false,
         scope: 'registration',
+        priv: null,
     },
     {
         label: 'This is a secured section of the form for administrators only',
@@ -185,6 +211,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        priv: null,
     },
     {
         name: 'isMonitor',
@@ -208,6 +235,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        priv: null,
     },
     {
         name: 'isSponsor',
@@ -215,5 +243,6 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        priv: null,
     },
 ];

--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -4,7 +4,7 @@ import React, {useEffect, useMemo, useState} from 'react';
 import {Link} from 'react-router-dom';
 import {ArrowLeft} from 'lucide-react';
 import {FormField} from '@/data/registrationFormData';
-import {generatePin, safeFieldName} from '@/features/registration/utils';
+import {generatePin, isInputField} from '@/features/registration/utils';
 import {Button} from '@/components/ui/button';
 import {Message} from '@/components/ui/message';
 import AppLayout from '@/components/layout/AppLayout';
@@ -35,8 +35,8 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}
     const hasUpdatePrivilege = useMemo(
         () =>
             fields
+                .filter(isInputField)
                 .filter((f) => f.priv === 'update')
-                .filter(safeFieldName)
                 .some((f) => Boolean(initialData?.[f.name])),
         [fields, initialData]
     );
@@ -59,10 +59,11 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}
     const visibleFields = useMemo(
         () =>
             fields.filter((f) => {
-                if (!safeFieldName(f)) return true;
-                if (!showId && f.name === 'id') return false;
-                if (!isSaved && ['isCancelled', 'cancelledAttendance'].includes(f.name)) return false;
-                if (!state.hasProxy && PROXY_FIELDS_SET.has(f.name)) return false;
+                if (isInputField(f)) {
+                    if (!showId && f.name === 'id') return false;
+                    if (!isSaved && ['isCancelled', 'cancelledAttendance'].includes(f.name)) return false;
+                    if (!state.hasProxy && PROXY_FIELDS_SET.has(f.name)) return false;
+                }
                 return !(f.scope === 'admin' && !hasUpdatePrivilege);
             }),
         [fields, showId, hasUpdatePrivilege, state.hasProxy, isSaved]
@@ -83,7 +84,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}
         e.preventDefault();
 
         const requiredMissing = visibleFields
-            .filter(safeFieldName)
+            .filter(isInputField)
             .filter((f) => f.required || (state.hasProxy && PROXY_FIELDS_SET.has(f.name)))
             .filter((f) => {
                 const value = state[f.name];

--- a/frontend/src/features/registration/components/AdminSection.tsx
+++ b/frontend/src/features/registration/components/AdminSection.tsx
@@ -17,14 +17,14 @@ const AdminSection: React.FC<SectionProps> = ({fields, state, dispatch, isMissin
         if (f.type === 'section') {
             return f.label === ADMIN_SECTION_LABEL;
         }
-        return ADMIN_FIELD_SET.has(f.name ?? '');
+        return ADMIN_FIELD_SET.has(f.name);
     });
 
     return (
         <>
             {sectionFields.map((field) => (
                 <FieldRenderer
-                    key={field.name || field.label}
+                    key={field.type === 'section' ? field.label : field.name}
                     field={field}
                     state={state}
                     dispatch={dispatch}

--- a/frontend/src/features/registration/components/ContactInfoSection.tsx
+++ b/frontend/src/features/registration/components/ContactInfoSection.tsx
@@ -17,14 +17,14 @@ const ContactInfoSection: React.FC<SectionProps> = ({fields, state, dispatch, is
         if (f.type === 'section') {
             return f.label === CONTACT_INFO_LABEL;
         }
-        return CONTACT_FIELD_SET.has(f.name ?? '');
+        return CONTACT_FIELD_SET.has(f.name);
     });
 
     return (
         <>
             {sectionFields.map((field) => (
                 <FieldRenderer
-                    key={field.name || field.label}
+                    key={field.type === 'section' ? field.label : field.name}
                     field={field}
                     state={state}
                     dispatch={dispatch}

--- a/frontend/src/features/registration/components/FieldRenderer.tsx
+++ b/frontend/src/features/registration/components/FieldRenderer.tsx
@@ -6,7 +6,6 @@ import {Input} from '@/components/ui/input';
 import {Label} from '@/components/ui/label';
 import {Checkbox} from '@/components/ui/checkbox-wrapper';
 import {Section} from '@/components/ui/section';
-import {safeFieldName} from '../utils';
 
 interface FieldRendererProps {
     field: FormField;
@@ -20,8 +19,6 @@ const FieldRenderer: React.FC<FieldRendererProps> = ({field, state, dispatch, is
     if (field.type === 'section') {
         return <Section>{field.label}</Section>;
     }
-
-    if (!safeFieldName(field)) return null;
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const {name, type, value, valueAsNumber} = e.target;

--- a/frontend/src/features/registration/components/ProxyInfoSection.tsx
+++ b/frontend/src/features/registration/components/ProxyInfoSection.tsx
@@ -17,14 +17,14 @@ const ProxyInfoSection: React.FC<SectionProps> = ({fields, state, dispatch, isMi
         if (f.type === 'section') {
             return f.label === PROXY_INFO_LABEL;
         }
-        return PROXY_WITH_FLAG_SET.has(f.name ?? '');
+        return PROXY_WITH_FLAG_SET.has(f.name);
     });
 
     return (
         <>
             {sectionFields.map((field) => (
                 <FieldRenderer
-                    key={field.name || field.label}
+                    key={field.type === 'section' ? field.label : field.name}
                     field={field}
                     state={state}
                     dispatch={dispatch}

--- a/frontend/src/features/registration/components/RegistrationInfoSection.tsx
+++ b/frontend/src/features/registration/components/RegistrationInfoSection.tsx
@@ -17,14 +17,14 @@ const RegistrationInfoSection: React.FC<SectionProps> = ({fields, state, dispatc
         if (f.type === 'section') {
             return f.label === PIN_INFO_LABEL || f.label === CANCELLATION_LABEL;
         }
-        return REGISTRATION_FIELD_SET.has(f.name ?? '');
+        return REGISTRATION_FIELD_SET.has(f.name);
     });
 
     return (
         <>
             {sectionFields.map((field) => (
                 <FieldRenderer
-                    key={field.name || field.label}
+                    key={field.type === 'section' ? field.label : field.name}
                     field={field}
                     state={state}
                     dispatch={dispatch}

--- a/frontend/src/features/registration/state/formReducer.ts
+++ b/frontend/src/features/registration/state/formReducer.ts
@@ -12,31 +12,27 @@ export type FormValue = string | boolean | number;
 export type FormState = Record<string, FormValue>;
 
 export const initialFormState = (fields: FormField[]): FormState =>
-    fields.reduce((acc, {name, type}) => {
+    fields.reduce((acc, field) => {
+        if (field.type === 'section') return acc;
 
-        switch (type) {
-
+        switch (field.type) {
             // boolean flags
             case 'checkbox':
-                acc[name] = false;
+                acc[field.name] = false;
                 break;
 
             // numeric inputs
             case 'number':
-                acc[name] = 0;
+                acc[field.name] = 0;
                 break;
 
-            // UI-only sections—no state entry
-            case 'section':
-                break;
-
-            // everything else (text, email, phone, hidden, pin)
+            // everything else (text, email, phone, pin)
             case 'text':
             case 'email':
             case 'phone':
             case 'pin':
             default:
-                acc[name] = '';
+                acc[field.name] = '';
         }
         return acc;
     }, {} as FormState);

--- a/frontend/src/features/registration/utils.ts
+++ b/frontend/src/features/registration/utils.ts
@@ -1,11 +1,11 @@
 // frontend/src/features/registration/utils.ts
 //
 
-import {FormField} from '@/data/registrationFormData';
+import {FormField, FormInputField} from '@/data/registrationFormData';
 
-// Type guard to ensure field.name is a string, required for field-safe rendering.
-export function safeFieldName(field: FormField): field is FormField & { name: string } {
-    return typeof field.name === 'string';
+// Type guard to narrow a form element to an input field.
+export function isInputField(field: FormField): field is FormInputField {
+    return field.type !== 'section';
 }
 
 // Generate a random Pin for a new registration user.


### PR DESCRIPTION
## Summary
- separate form fields into `FormInputField` and `FormSectionHeading`
- update registration form utilities, reducer and components to use new field types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --prefix backend test` *(fails: ReferenceError: describe is not defined)*
- `npm --prefix frontend test` *(fails: Missing script "test")*
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_6890e764506483228ec6e28949a05d46