### PR TITLE
Disable pin request checkbox when pin provided

### DIFF
--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -103,6 +103,13 @@ const HomePage: React.FC<HomePageProps> = ({onSuccess}) => {
         }
     }, [email]);
 
+    useEffect(() => {
+        if (pin.trim() !== '') {
+            setEmailPinChecked(false);
+            setPinMessage(null);
+        }
+    }, [pin]);
+
     const canSubmit = isValidEmail(email) && pin.trim() !== '';
 
     return (
@@ -163,7 +170,7 @@ const HomePage: React.FC<HomePageProps> = ({onSuccess}) => {
                         label="Please email my pin."
                         checked={emailPinChecked}
                         onCheckedChange={handleEmailPin}
-                        disableUnless={isValidEmail(email)}
+                        disableUnless={isValidEmail(email) && pin.trim() === ''}
                     />
                     {pinMessage && (
                         <Message text={pinMessage.text} isError={pinMessage.isError}/>


### PR DESCRIPTION
## Summary
- Disable 'email my pin' checkbox when user enters a pin on the homepage
- Auto-clear pin request state whenever a pin is supplied

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689916275a808322a876c0b455ef1c4c