### PR TITLE
feat: indicate required fields

### DIFF
--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -137,7 +137,9 @@ const HomePage: React.FC<HomePageProps> = ({onSuccess}) => {
                 <div id="update-section" className="space-y-4">
                     <hr className="my-4"/>
                     <div className="flex flex-col gap-1">
-                        <Label htmlFor="email">Email</Label>
+                        <Label htmlFor="email">
+                            Email<sup className="text-red-500">*</sup>
+                        </Label>
                         <Input
                             id="email"
                             type="email"
@@ -151,7 +153,9 @@ const HomePage: React.FC<HomePageProps> = ({onSuccess}) => {
                         )}
                     </div>
                     <div className="flex flex-col gap-1">
-                        <Label htmlFor="pin">Pin</Label>
+                        <Label htmlFor="pin">
+                            Pin<sup className="text-red-500">*</sup>
+                        </Label>
                         <Input
                             id="pin"
                             type="text"

--- a/frontend/src/features/registration/FieldFactory.tsx
+++ b/frontend/src/features/registration/FieldFactory.tsx
@@ -52,7 +52,10 @@ export function FieldRenderer({field, state, isMissing, onCheckboxChange, onInpu
 
     return (
         <div key={field.name} className="flex flex-col gap-1">
-            <Label htmlFor={field.name}>{field.label}</Label>
+            <Label htmlFor={field.name}>
+                {field.label}
+                {field.required && <sup className="text-red-500">*</sup>}
+            </Label>
             <Input
                 id={field.name}
                 name={field.name}


### PR DESCRIPTION
## Summary
- show required login fields with red asterisks on the home page
- mark default-required registration fields with asterisks

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899392c19cc8322992c8395d2cee5f6