### PR TITLE
fix: stabilize logging configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,3 +14,4 @@ FRONTEND_PORT="3000"
 LOG_LEVEL="info"
 LOG_TO_FILE="true"
 LOG_DIR=./logs
+LOG_PREFIX="app"

--- a/Makefile
+++ b/Makefile
@@ -12,22 +12,28 @@ SET_BACKEND_ENV := set -a && . $(CURDIR)/.env && set +a && cd $(BACKEND_DIR) &&
 ##–––––– Logs ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
 
 logs: ## View logs for current environment (dev if LOG_DIR is set to ./logs, else prod)
-	@if [ "$$(grep -E '^LOG_DIR=\.\/logs' .env 2>/dev/null)" != "" ]; then \
-	  if [ -f ./logs/app.log ]; then \
-	    echo " - showing dev logs from ./logs/app.log"; \
-	    less ./logs/app.log; \
+	@LOG_PREFIX=$$(grep -E '^LOG_PREFIX=' .env 2>/dev/null | cut -d= -f2 | tr -d '\r'); \
+	[ -z "$$LOG_PREFIX" ] && LOG_PREFIX=app; \
+	if [ "$$(grep -E '^LOG_DIR=\.\/logs' .env 2>/dev/null)" != "" ]; then \
+	  FILE=$$(ls -1 ./logs/$$LOG_PREFIX-*.log 2>/dev/null | tail -n 1); \
+	  if [ "$$FILE" != "" ]; then \
+	    echo " - showing dev logs from $$FILE"; \
+	    less $$FILE; \
 	  else \
-	    echo " - no dev log file found at ./logs/app.log"; \
+	    echo " - no dev log file found in ./logs"; \
 	  fi; \
 	else \
-	  echo " - showing prod logs from /var/log/conference/app.log inside container"; \
+	  echo " - showing prod logs from /var/log/conference inside container"; \
 	  docker compose exec -it conference-backend sh -c '\
-	    if [ -f /var/log/conference/app.log ]; then \
-	      less /var/log/conference/app.log; \
+	    LOG_PREFIX="'"$$LOG_PREFIX"'"; \
+	    FILE=$$(ls -1 /var/log/conference/$$LOG_PREFIX-*.log 2>/dev/null | tail -n 1); \
+	    if [ "$$FILE" != "" ]; then \
+	      less $$FILE; \
 	    else \
-	      echo " - no prod log file found at /var/log/conference/app.log"; \
+	      echo " - no prod log file found in /var/log/conference"; \
 	    fi'; \
 	fi
+
 
 ##–––––– Quick Start –––––––––––––––––––––––––––––––––––––––––––––––––––––––––
 

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -14,7 +14,7 @@
  *      LOG_LEVEL=info
  *      LOG_TO_FILE=true
  * 4) In production (container):
- *      LOG_DIR=/var/log/conference-reg
+ *      LOG_DIR=/var/log/conference
  *      LOG_LEVEL=info
  *      LOG_TO_FILE=true
  *      # mount LOG_DIR as a persistent volume
@@ -29,6 +29,11 @@ import fs from "fs";
 import path from "path";
 import { promises as fsp } from "fs";
 import type { Request, Response, NextFunction } from "express";
+import dotenv from "dotenv";
+
+// Load environment variables before reading them so that developers
+// using a local `.env` file get the correct logging configuration.
+dotenv.config();
 
 // ---------- Configuration ----------
 const LOG_DIR = process.env.LOG_DIR || path.join(process.cwd(), "logs");


### PR DESCRIPTION
## Summary
- ensure logger loads env vars and document prod log path
- allow Makefile logs target to show rotated files with prefix
- sample env includes log prefix for clarity

## Testing
- `cd backend && npm test` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68995081166c832290c70e80f933d2cd