### PR TITLE
Fix logger import for tslog

### DIFF
--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -2,11 +2,12 @@ import fs from "fs";
 import path from "path";
 import dotenv from "dotenv";
 import type { Request, Response, NextFunction } from "express";
+import { Logger as TsLogger, TLogLevelName } from "tslog";
 
 dotenv.config();
 
 const LOG_DIR = process.env.LOG_DIR || path.join(process.cwd(), "logs");
-const LOG_LEVEL = (process.env.LOG_LEVEL || "info");
+const LOG_LEVEL: TLogLevelName = (process.env.LOG_LEVEL as TLogLevelName) || "info";
 const LOG_TO_FILE = String(process.env.LOG_TO_FILE || "true").toLowerCase() === "true";
 const LOG_PREFIX = process.env.LOG_PREFIX || "app";
 
@@ -16,7 +17,7 @@ if (LOG_TO_FILE && !fs.existsSync(LOG_DIR)) {
 
 const logFilePath = path.join(LOG_DIR, `${LOG_PREFIX}.log`);
 
-export const log: Logger = new Logger({ minLevel: LOG_LEVEL });
+export const log: TsLogger = new TsLogger({ minLevel: LOG_LEVEL });
 
 if (LOG_TO_FILE) {
     log.attachTransport((logObj, logMeta) => {


### PR DESCRIPTION
## Summary
- import TsLogger and TLogLevelName from tslog
- type LOG_LEVEL and instantiate logger correctly

## Testing
- `npm test` (fails: ReferenceError: describe is not defined in node_modules/tsconfig)
- `npm run typecheck` (fails: TS6059 File not under rootDir)


------
https://chatgpt.com/codex/tasks/task_e_689d68540e4c8322a093194fe80e3e27