### PR TITLE
refactor: use centralized logger

### DIFF
--- a/backend/src/routes/registration.ts
+++ b/backend/src/routes/registration.ts
@@ -115,6 +115,7 @@ router.post<{}, any, CreateRegistrationBody>(
                 loginPin,
             });
 
+            log.info('Registration created', {id, email});
             res.status(201).json({id, loginPin});
         } catch (err) {
             log.error('Error saving registration', {error: err});
@@ -162,6 +163,7 @@ router.get(
                 return;
             }
 
+            log.info('Registration lookup successful', {email});
             res.json({registration});
         } catch (err) {
             log.error('Error fetching registration', {error: err});
@@ -203,7 +205,7 @@ router.get(
             }
 
             // In a real implementation, send the pin via email here.
-            log.info(`Sending pin ${credential.loginPin} to ${email}`);
+            log.info('Sending pin', {pin: credential.loginPin, email});
 
             res.json({sent: true});
         } catch (err) {
@@ -247,6 +249,7 @@ router.get<{ id: string }, any>(
                 return;
             }
 
+            log.info('Registration fetched', {id});
             res.json({registration});
         } catch (err) {
             log.error('Error fetching registration', {error: err});

--- a/backend/src/tests/route-test.ts
+++ b/backend/src/tests/route-test.ts
@@ -1,3 +1,5 @@
 // backend/src/tests/route-test.ts
 
-console.log("Route test file compiles and runs.");
+import {log} from "@/utils/logger";
+
+log.info("Route test file compiles and runs.");

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,4 +1,4 @@
-// backend/src/logger.ts
+// backend/src/utils/logger.ts
 //
 
 import fs from "fs";

--- a/backend/test/test-drizzle.js
+++ b/backend/test/test-drizzle.js
@@ -1,7 +1,0 @@
-"use strict";
-// backend/test/test-drizzle.tx
-//
-Object.defineProperty(exports, "__esModule", { value: true });
-var mysql_core_1 = require("drizzle-orm/mysql-core");
-var t = (0, mysql_core_1.mysqlTable)('my_test_table', {});
-console.log(t);

--- a/backend/test/test-drizzle.ts
+++ b/backend/test/test-drizzle.ts
@@ -2,6 +2,7 @@
 //
 
 import { mysqlTable } from 'drizzle-orm/mysql-core';
+import { log } from '@/utils/logger';
 
 const t = mysqlTable('my_test_table', {});
-console.log(t);
+log.info(t);

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
-        exclude: ['src/tests/**'],
+        exclude: ['src/tests/**', 'node_modules/**'],
     },
 });


### PR DESCRIPTION
## Summary
- ensure shared logger file reflects its location
- record registration lifecycle events using logger
- switch test files and vitest config to use centralized logger

## Testing
- `npm test -- -r`

------
https://chatgpt.com/codex/tasks/task_e_689d7b891ef88322b47112987dc2dc34