### PR TITLE
Handle registration save failures on backend

### DIFF
--- a/backend/src/routes/registration.ts
+++ b/backend/src/routes/registration.ts
@@ -45,6 +45,8 @@ function generatePin(length: number): string {
 
 const router = Router();
 
+const SAVE_REGISTRATION_ERROR = "Failed to save registration";
+
 // Columns marked as NOT NULL in the database schema. These need to be
 // present before attempting to insert a record.
 const REQUIRED_FIELDS: (keyof CreateRegistrationBody)[] = [
@@ -129,8 +131,8 @@ router.post<{}, any, CreateRegistrationBody>("/", async (req, res): Promise<void
         log.info("Registration created", {id, email});
         res.status(201).json({id, loginPin});
     } catch (err) {
-        sendError(res, 500, "Failed to save registration", {
-            cause: err instanceof Error ? err.message : String(err),
+        sendError(res, 500, SAVE_REGISTRATION_ERROR, {
+            error: err instanceof Error ? err : new Error(String(err)),
         });
     }
 });

--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -207,7 +207,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}
                 setMessage({text: 'Registration saved successfully.', type: 'success'});
             } else {
                 const data = await res.json().catch(() => ({}));
-                setMessage({text: data.error ?? 'Failed to save registration', type: 'error'});
+                setMessage({text: data.error, type: 'error'});
             }
         } catch (err) {
             console.error('Registration submission failed', err);


### PR DESCRIPTION
## Summary
- define a single `SAVE_REGISTRATION_ERROR` message for failed registration saves
- log underlying error and return the message to the client
- frontend displays backend-provided error text instead of hard-coded copy

## Testing
- `npm test` (backend)
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689fe536e00c832287dd1ac663f81370