### PR TITLE
Use dedicated backend port and proxy API requests

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,7 @@ DB_PASSWORD=sample.pwd
 DB_ROOT_PASSWORD=sample.root.pwd
 DB_USER=sampler
 
+BACKEND_HOST=conference-backend
 BACKEND_PORT=5000
 DB_PORT=3306
 FRONTEND_PORT=3000

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,7 +12,7 @@ import {errorLogger, log, requestLogger} from "@/utils/logger";
 dotenv.config();
 
 const app = express();
-const port = process.env.DB_PORT || 5000;
+const port = process.env.BACKEND_PORT || process.env.PORT || 5000;
 
 app.use(cors());
 app.use(express.json());

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,8 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig(({mode}) => {
     const env = loadEnv(mode, process.cwd(), '');
+    const backendPort = parseInt(env.BACKEND_PORT) || 5000;
+    const backendHost = env.BACKEND_HOST || 'localhost';
 
     return {
         root: '.', // implicit
@@ -12,6 +14,12 @@ export default defineConfig(({mode}) => {
         server: {
             host: true,
             port: parseInt(env.UI_PORT) || 3000,
+            proxy: {
+                '/api': {
+                    target: `http://${backendHost}:${backendPort}`,
+                    changeOrigin: true,
+                },
+            },
         },
         build: {
             outDir: 'dist',        // ← explicit output folder


### PR DESCRIPTION
## Summary
- Fix backend server to read `BACKEND_PORT` (or `PORT`) instead of the database port
- Proxy frontend `/api` calls to the backend using `BACKEND_HOST`/`BACKEND_PORT`
- Document backend host/port in `.env.sample`

## Testing
- `npm test` (backend) – no test files found
- `npm test` (frontend) – missing script: test


------
https://chatgpt.com/codex/tasks/task_e_68a0e774298c8322b2e894e365f2ca8d