### PR TITLE
feat: hide and copy login pin

### DIFF
--- a/frontend/src/features/registration/FieldFactory.tsx
+++ b/frontend/src/features/registration/FieldFactory.tsx
@@ -8,6 +8,7 @@ import {Label} from '@/components/ui/label';
 import {Checkbox} from '@/components/ui/checkbox-wrapper';
 import {Section} from '@/components/ui/section';
 import {Message} from '@/components/ui/message';
+import {Copy, Eye, EyeOff} from 'lucide-react';
 
 type Props = {
     field: FormField;
@@ -19,6 +20,8 @@ type Props = {
 };
 
 export function FieldRenderer({field, state, isMissing, onCheckboxChange, onInputChange, error}: Props) {
+    const [pinVisible, setPinVisible] = React.useState(false);
+
     if (field.type === 'section') {
         return <Section key={`section-${field.label}`}>{field.label}</Section>;
     }
@@ -46,9 +49,52 @@ export function FieldRenderer({field, state, isMissing, onCheckboxChange, onInpu
         );
     }
 
-    // text, email, phone, number, pin
-    const isReadOnly = field.type === 'pin' || field.name === 'id';
-    const inputType = field.type === 'pin' ? 'text' : field.type;
+    if (field.type === 'pin') {
+        const pinValue = String(state[field.name] ?? '');
+        const copyPin = () => navigator.clipboard.writeText(pinValue);
+
+        return (
+            <div key={field.name} className="flex flex-col gap-1">
+                <Label htmlFor={field.name}>
+                    {field.label}
+                    {field.required && <sup className="text-red-500">*</sup>}
+                </Label>
+                <div className="relative">
+                    <Input
+                        id={field.name}
+                        name={field.name}
+                        type={pinVisible ? 'text' : 'password'}
+                        value={pinValue}
+                        readOnly
+                        className={`${isMissing(field.name) || error ? 'bg-red-100' : ''} pr-16`}
+                    />
+                    <div className="absolute inset-y-0 right-0 flex items-center gap-1 pr-2">
+                        <button
+                            type="button"
+                            onClick={copyPin}
+                            className="p-1 text-muted-foreground hover:text-foreground"
+                            aria-label="Copy PIN"
+                        >
+                            <Copy className="h-4 w-4" />
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setPinVisible((v) => !v)}
+                            className="p-1 text-muted-foreground hover:text-foreground"
+                            aria-label={pinVisible ? 'Hide PIN' : 'Show PIN'}
+                        >
+                            {pinVisible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                        </button>
+                    </div>
+                </div>
+                {error && <Message text={error} isError />}
+            </div>
+        );
+    }
+
+    // text, email, phone, number
+    const isReadOnly = field.name === 'id';
+    const inputType = field.type;
 
     return (
         <div key={field.name} className="flex flex-col gap-1">


### PR DESCRIPTION
## Summary
- hide login pin input behind password mask
- add actions to copy PIN and toggle visibility

## Testing
- `npm test` *(fails: Missing script)*
- `cd frontend && npm test` *(fails: Missing script)*
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a285a523e883228d9aed56761826a6