### PR TITLE
fix: hide proxy fields on existing registrations

### DIFF
--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -80,13 +80,8 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({fields, initialData}
         [fields, state, hasUpdatePrivilege, isSaved, showId]
     );
 
-    // Hide hasProxy when editing (isSaved true)
-    const fieldsForRender = useMemo(() => {
-        if (isSaved) {
-            return visibleFields.filter((f) => f.name !== 'hasProxy');
-        }
-        return visibleFields;
-    }, [visibleFields, isSaved]);
+    // Proxy-related fields are filtered in formRules when editing
+    const fieldsForRender = visibleFields;
 
     // Effects
 

--- a/frontend/src/features/registration/formRules.ts
+++ b/frontend/src/features/registration/formRules.ts
@@ -48,6 +48,13 @@ export function canSeeField(
     const {state, hasUpdatePrivilege, isSaved, showId} = ctx;
 
     if (!showId && field.name === 'id') return false;
+    if (
+        isSaved &&
+        (field.name === 'hasProxy' ||
+            PROXY_FIELDS_SET.has(field.name) ||
+            (field.type === 'section' && field.name === 'section-proxy'))
+    )
+        return false;
     if (!isSaved && CANCEL_FIELDS_SET.has(field.name)) return false;
     if (!state.hasProxy && PROXY_FIELDS_SET.has(field.name)) return false;
     if (field.scope === 'admin' && !hasUpdatePrivilege) return false;


### PR DESCRIPTION
## Summary
- hide proxy section and fields when editing an existing registration
- rely on form rules to filter proxy fields

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2925ece048322912278f79804906f