### PR TITLE
chore: add dependency update command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,13 @@ update-schema: ## Generate new migrations and apply them (current profile/env)
 	$(MAKE) generate
 	$(MAKE) schema
 
+##–––––– Dependencies ––––––––––––––––––––––––––––––––––––––––––––––––––––––––
+
+update-dependencies: ## Update npm dependencies in root, backend, and frontend
+	@npm update
+	@cd $(BACKEND_DIR) && npm update
+	@cd $(FRONTEND_DIR) && npm update
+
 ##–––––– Profile Shortcuts ––––––––––––––––––––––––––––––––––––––––––––––––––
 
 prod-build: ## Build images using .env.prod
@@ -249,5 +256,5 @@ help: ## Show available targets grouped by section (honors ENV_PROFILE=prod)
 
 .PHONY: build clean commit-migration deploy down drop-tables generate \
         help init init-backend backend-shell restart reset-db schema \
-        studio studio-cert studio-check tail-logs update-schema up \
+        studio studio-cert studio-check tail-logs update-schema update-dependencies up \
         rebuild logs prod-build prod-up prod-down prod-deploy


### PR DESCRIPTION
## Summary
- add a convenience `update-dependencies` target to update root, backend, and frontend packages

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68ab9f1bdaf0832280a880d333741a8b