### PR TITLE
Allow frontend to start without TLS certs

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,27 +4,34 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 import * as fs from 'fs';
 import * as path from 'path';
 
-export default defineConfig(({ command, mode }) => {
+export default defineConfig(({ command }) => {
     const isDev = command === 'serve';
+
+    const keyPath = path.resolve('/certs/localhost-key.pem');
+    const certPath = path.resolve('/certs/localhost.pem');
+    const httpsOptions =
+        fs.existsSync(keyPath) && fs.existsSync(certPath)
+            ? {
+                  key: fs.readFileSync(keyPath),
+                  cert: fs.readFileSync(certPath),
+              }
+            : undefined;
 
     return {
         plugins: [react(), tsconfigPaths()],
         server: isDev
             ? {
-                host: true,
-                port: 3000,
-                https: {
-                    key: fs.readFileSync(path.resolve('/certs/localhost-key.pem')),
-                    cert: fs.readFileSync(path.resolve('/certs/localhost.pem')),
-                },
-                proxy: {
-                    '/api': {
-                        target: 'https://conference-backend:5000',
-                        changeOrigin: true,
-                        secure: false,
-                    },
-                },
-            }
+                  host: true,
+                  port: 3000,
+                  https: httpsOptions,
+                  proxy: {
+                      '/api': {
+                          target: 'https://conference-backend:5000',
+                          changeOrigin: true,
+                          secure: false,
+                      },
+                  },
+              }
             : undefined,
         build: {
             outDir: 'dist',


### PR DESCRIPTION
## Summary
- load HTTPS certificates for the dev server only when they exist

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68abd678faa08322946d9442af9c29e6