### PR TITLE
Serve UI via HTTPS proxy on port 8080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   proxy:
     image: nginx:alpine
     ports:
-      - "80:80"
+      - "8080:8080"
     environment:
       INTERNAL_SECRET: ${INTERNAL_SECRET}
       # tell nginx where the template is and where to write the rendered config
@@ -11,6 +11,7 @@ services:
       NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx
     volumes:
       - ./nginx.conf.template:/etc/nginx/templates/nginx.conf.template:ro
+      - ./backend/certs:/etc/nginx/certs:ro
     depends_on:
       - conference-backend
       - conference-ui

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,8 +2,11 @@ worker_processes auto;
 events { worker_connections 1024; }
 http {
   server {
-    listen 80;
+    listen 8080 ssl;
     server_name _;
+
+    ssl_certificate /etc/nginx/certs/localhost.pem;
+    ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
 
     location / {
       proxy_pass http://conference-ui:3000/;

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -2,8 +2,11 @@ worker_processes auto;
 events { worker_connections 1024; }
 http {
   server {
-    listen 80;
+    listen 8080 ssl;
     server_name _;
+
+    ssl_certificate /etc/nginx/certs/localhost.pem;
+    ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
 
     location / {
       proxy_pass http://conference-ui:3000/;


### PR DESCRIPTION
## Summary
- Expose Nginx proxy on host port 8080 and mount TLS certificates
- Configure Nginx to terminate HTTPS on port 8080 and forward to UI and API services

## Testing
- `npm test -- --run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd88053d883228bd0f43d7c40f3b7