### PR TITLE
feat: add PIN-based registration guard

### DIFF
--- a/backend/src/middleware/requirePin.ts
+++ b/backend/src/middleware/requirePin.ts
@@ -1,0 +1,33 @@
+import type { RequestHandler } from "express";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/client";
+import { registrations, credentials } from "@/db/schema";
+
+export const requirePin: RequestHandler = async (req, res, next) => {
+  try {
+    const email = (req.body?.email ?? req.query?.email ?? "").toString().trim().toLowerCase();
+    const pin = (req.body?.pin ?? req.query?.pin ?? "").toString();
+
+    if (!email || !pin) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+
+    const [row] = await db
+      .select({ registrationId: credentials.registrationId })
+      .from(registrations)
+      .innerJoin(credentials, eq(credentials.registrationId, registrations.id))
+      .where(and(eq(registrations.email, email), eq(credentials.loginPin, pin)))
+      .limit(1);
+
+    if (!row) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+
+    (req as any).registrationAuth = { email, registrationId: row.registrationId };
+    next();
+  } catch (e) {
+    res.status(500).json({ error: "server error" });
+  }
+};


### PR DESCRIPTION
## Summary
- require email+PIN for protected registration routes
- add middleware to verify credentials and gate access

## Testing
- `cd backend && npm test -- --run` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b3da8276ec83228f44d8f3d38e8c6d