### PR TITLE
refactor: centralize db error logging

### DIFF
--- a/backend/src/routes/registration.ts
+++ b/backend/src/routes/registration.ts
@@ -339,9 +339,9 @@ router.get("/lost-pin", async (req, res): Promise<void> => {
         log.info("Sending pin", {email, registrationId: registration.id});
         res.json({sent: true});
     } catch (err) {
-        log.error("Failed to send pin", {
+        logDbError(log, err, {
+            message: "Failed to send pin",
             email,
-            cause: err instanceof Error ? err.message : String(err),
         });
         sendError(res, 500, "Failed to send pin", {
             email,
@@ -382,10 +382,10 @@ router.get<{ id: string }, any>("/:id", requirePin, ownerOnly, async (req, res):
             },
         });
     } catch (err) {
-        log.error("Failed to fetch registration by id", {
+        logDbError(log, err, {
+            message: "Failed to fetch registration by id",
             email: undefined,
             registrationId: id,
-            cause: err instanceof Error ? err.message : String(err),
         });
         sendError(res, 500, "Failed to fetch registration", {
             id,

--- a/backend/src/utils/dbErrorLogger.ts
+++ b/backend/src/utils/dbErrorLogger.ts
@@ -2,12 +2,16 @@
 
 import { dbErrorDetails } from "./dbErrors";
 
-export function logDbError(log: {
-        error: (arg0: any, arg1: {
-            mysqlCode: any; mysqlErrno: any; sqlState: any; sqlMessage: any; sql: any; // toggle or redact in prod if needed
-            stack: string | undefined;
-        }) => void;
-    }, err: unknown, context: Record<string, any> = {}) {
+/**
+ * Log a database-related error with standardized fields.
+ * Extracts MySQL codes and stack traces so that callers emit
+ * consistent error logs across the application.
+ */
+export function logDbError(
+    log: { error: (message: string, details: Record<string, unknown>) => void },
+    err: unknown,
+    context: Record<string, unknown> = {}
+): void {
     const db = dbErrorDetails(err);
     log.error(context.message ?? "DB operation failed", {
         ...context,
@@ -15,7 +19,7 @@ export function logDbError(log: {
         mysqlErrno: db.mysqlErrno,
         sqlState: db.sqlState,
         sqlMessage: db.sqlMessage,
-        sql: db.sql,           // toggle or redact in prod if needed
+        sql: db.sql, // toggle or redact in prod if needed
         stack: err instanceof Error ? err.stack : undefined,
     });
 }


### PR DESCRIPTION
## Summary
- add `logDbError` helper to standardize database error logs
- use `logDbError` in registration routes instead of `log.error`

## Testing
- `npm test`
- `npx ts-node -e "import {log} from './src/utils/logger'; import {logDbError} from './src/utils/dbErrorLogger'; logDbError(log, {code:'ER_DUP_ENTRY', errno:1062, sqlState:'23000', sqlMessage:'Duplicate entry', sql:'INSERT 1'}, {message:'Test DB error', email:'test@example.com'});"`


------
https://chatgpt.com/codex/tasks/task_e_68b4bbc40c6083229e3d6657ea51b732