### PR TITLE
Sanitize registration error responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ node_modules/
 backend/node_modules/
 /backend/dist/
 /backend/drizzle/migrations/
+/backend/logs/
+/backend/tsconfig.tsbuildinfo
 /frontend/dist/
 *.pem
 /frontend/src/**/*.js

--- a/backend/src/routes/registration.errors.test.ts
+++ b/backend/src/routes/registration.errors.test.ts
@@ -1,0 +1,67 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    getRegistrationByEmail: vi.fn(),
+    getCredentialByRegId: vi.fn(),
+    getRegistrationWithPinById: vi.fn(),
+    logDbError: vi.fn(),
+}));
+
+vi.mock('./registration.service', () => ({
+    createRegistration: vi.fn(),
+    getCredentialByRegId: (...args: any[]) => mocks.getCredentialByRegId(...args),
+    getRegistrationByEmail: (...args: any[]) => mocks.getRegistrationByEmail(...args),
+    getRegistrationWithPinById: (...args: any[]) => mocks.getRegistrationWithPinById(...args),
+    getRegistrationWithPinByLogin: vi.fn(),
+    updateRegistration: vi.fn(),
+}));
+
+vi.mock('@/middleware/requirePin', () => ({
+    requirePin: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('@/utils/email', () => ({
+    sendEmail: vi.fn(),
+}));
+
+vi.mock('@/utils/dbErrorLogger', () => ({
+    logDbError: (...args: any[]) => mocks.logDbError(...args),
+}));
+
+import router from './registration';
+
+describe('registration error handling', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('lost pin hides internal error details', async () => {
+        mocks.getRegistrationByEmail.mockRejectedValue(new Error('db fail'));
+        const app = express();
+        app.use('/', router);
+        const res = await request(app).get('/lost-pin?email=test@example.com');
+        expect(res.status).toBe(500);
+        expect(res.body).toEqual({ error: 'Failed to send pin' });
+        expect(res.body).not.toHaveProperty('cause');
+        expect(res.body).not.toHaveProperty('stack');
+        expect(mocks.logDbError).toHaveBeenCalled();
+    });
+
+    test('fetch by id hides internal error details', async () => {
+        mocks.getRegistrationWithPinById.mockRejectedValue(new Error('db fail'));
+        const app = express();
+        app.use((req, _res, next) => {
+            (req as any).registrationAuth = { registrationId: 1 };
+            next();
+        });
+        app.use('/', router);
+        const res = await request(app).get('/1');
+        expect(res.status).toBe(500);
+        expect(res.body).toEqual({ error: 'Failed to fetch registration' });
+        expect(res.body).not.toHaveProperty('cause');
+        expect(res.body).not.toHaveProperty('stack');
+        expect(mocks.logDbError).toHaveBeenCalled();
+    });
+});

--- a/backend/src/routes/registration.ts
+++ b/backend/src/routes/registration.ts
@@ -343,10 +343,8 @@ router.get("/lost-pin", async (req, res): Promise<void> => {
             message: "Failed to send pin",
             email,
         });
-        sendError(res, 500, "Failed to send pin", {
-            email,
-            cause: err instanceof Error ? err.message : String(err),
-        });
+        // Do not expose internal error details to the client
+        sendError(res, 500, "Failed to send pin");
     }
 });
 
@@ -387,10 +385,8 @@ router.get<{ id: string }, any>("/:id", requirePin, ownerOnly, async (req, res):
             email: undefined,
             registrationId: id,
         });
-        sendError(res, 500, "Failed to fetch registration", {
-            id,
-            cause: err instanceof Error ? err.message : String(err),
-        });
+        // Do not expose internal error details to the client
+        sendError(res, 500, "Failed to fetch registration");
     }
 });
 

--- a/backend/src/types/supertest.d.ts
+++ b/backend/src/types/supertest.d.ts
@@ -1,0 +1,1 @@
+declare module 'supertest';

--- a/backend/src/utils/dbErrorLogger.ts
+++ b/backend/src/utils/dbErrorLogger.ts
@@ -13,7 +13,8 @@ export function logDbError(
     context: Record<string, unknown> = {}
 ): void {
     const db = dbErrorDetails(err);
-    log.error(context.message ?? "DB operation failed", {
+    const message = typeof context.message === "string" ? context.message : "DB operation failed";
+    log.error(message, {
         ...context,
         mysqlCode: db.mysqlCode,
         mysqlErrno: db.mysqlErrno,


### PR DESCRIPTION
## Summary
- Avoid exposing internal error causes in registration routes
- Improve database error logging helper
- Add regression tests verifying user-friendly error payloads

## Testing
- `npm test --prefix backend`
- `npm run typecheck --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68b4bd27079c8322855bed6b0de2bf00