### PR TITLE
Move route tests to backend tests directory

### DIFF
--- a/backend/tests/registration.errors.test.ts
+++ b/backend/tests/registration.errors.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
     logDbError: vi.fn(),
 }));
 
-vi.mock('./registration.service', () => ({
+vi.mock('@/routes/registration.service', () => ({
     createRegistration: vi.fn(),
     getCredentialByRegId: (...args: any[]) => mocks.getCredentialByRegId(...args),
     getRegistrationByEmail: (...args: any[]) => mocks.getRegistrationByEmail(...args),
@@ -30,7 +30,7 @@ vi.mock('@/utils/dbErrorLogger', () => ({
     logDbError: (...args: any[]) => mocks.logDbError(...args),
 }));
 
-import router from './registration';
+import router from '@/routes/registration';
 
 describe('registration error handling', () => {
     beforeEach(() => {
@@ -43,7 +43,7 @@ describe('registration error handling', () => {
         app.use('/', router);
         const res = await request(app).get('/lost-pin?email=test@example.com');
         expect(res.status).toBe(500);
-        expect(res.body).toEqual({ error: 'Failed to send pin' });
+        expect(res.body).toEqual({ error: 'Failed to send PIN' });
         expect(res.body).not.toHaveProperty('cause');
         expect(res.body).not.toHaveProperty('stack');
         expect(mocks.logDbError).toHaveBeenCalled();

--- a/backend/tests/registration.ownerOnly.test.ts
+++ b/backend/tests/registration.ownerOnly.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
     logDbError: vi.fn(),
 }));
 
-vi.mock('./registration.service', () => ({
+vi.mock('@/routes/registration.service', () => ({
     createRegistration: vi.fn(),
     getCredentialByRegId: (...args: any[]) => mocks.getCredentialByRegId(...args),
     getRegistrationByEmail: (...args: any[]) => mocks.getRegistrationByEmail(...args),
@@ -30,7 +30,7 @@ vi.mock('@/utils/dbErrorLogger', () => ({
     logDbError: (...args: any[]) => mocks.logDbError(...args),
 }));
 
-import router from './registration';
+import router from '@/routes/registration';
 
 describe('ownerOnly registration id', () => {
     beforeEach(() => {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -22,6 +22,7 @@
         "dist",
         "src/tests",
         "test",
+        "tests",
         "../drizzle.config.ts",
         "../vitest.config.ts",
         "../vite.config.ts"


### PR DESCRIPTION
## Summary
- relocate route tests from `src/routes` into new `backend/tests` folder
- update imports to use `@` alias and adjust expectation casing
- exclude `tests` directory from TypeScript config

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4f00ac6f48322942c4a21889741af