### PR TITLE
Align registration update validation with create requirements

### DIFF
--- a/backend/src/routes/registration.ts
+++ b/backend/src/routes/registration.ts
@@ -13,6 +13,7 @@ import {
     hasInvalidPhones,
     isValidEmail,
     missingRequiredFields,
+    REQUIRED_FIELDS,
     toNull,
     toTinyInt,
 } from "./registration.utils";
@@ -106,7 +107,7 @@ router.post("/", async (req: Request, res: Response): Promise<void> => {
         return;
     }
 
-    const missing = missingRequiredFields(req.body);
+    const missing = missingRequiredFields(req.body, false, REQUIRED_FIELDS);
     if (missing.length) {
         sendError(res, 400, "Missing required information", { missing });
         return;
@@ -196,7 +197,7 @@ router.put("/:id", requireAuth, csrfProtection, ownerOnly,
             return;
         }
 
-        const missing = missingRequiredFields(req.body, true);
+        const missing = missingRequiredFields(req.body, true, REQUIRED_FIELDS);
         if (missing.length) {
             sendError(res, 400, "Missing required information", { missing });
             return;

--- a/backend/tests/registration.validation.test.ts
+++ b/backend/tests/registration.validation.test.ts
@@ -101,5 +101,37 @@ describe('registration validation', () => {
         });
         expect(mocks.updateRegistration).not.toHaveBeenCalled();
     });
+
+    test('update allows optional fields to be omitted', async () => {
+        const app = express();
+        app.use(express.json());
+        app.use((req, _res, next) => {
+            (req as any).registrationAuth = { registrationId: 1 };
+            next();
+        });
+        app.use('/', router);
+
+        mocks.updateRegistration.mockResolvedValue({ rowsAffected: 1 });
+        mocks.getRegistrationWithPinById.mockResolvedValue([
+            {
+                registrations: {
+                    id: 1,
+                    email: 'user@example.com',
+                    lastName: 'X',
+                    question1: 'a',
+                    question2: 'b',
+                    firstName: 'John',
+                },
+                credentials: { loginPin: '12345678' },
+            },
+        ]);
+
+        const res = await request(app)
+            .put('/1')
+            .send({ firstName: 'John' });
+
+        expect(res.status).toBe(200);
+        expect(mocks.updateRegistration).toHaveBeenCalledWith(1, { firstName: 'John' });
+    });
 });
 


### PR DESCRIPTION
## Summary
- Ensure update route uses the same required-field list as creation by explicitly passing `REQUIRED_FIELDS`
- Add regression test confirming optional fields like phone numbers are not required on update

## Testing
- `npm test` *(fails to locate tests: "No test files found")*

------
https://chatgpt.com/codex/tasks/task_e_68bd069bc2ac83228cf8557e5088077f