### PR TITLE
Add administration workflow and registration listing

### DIFF
--- a/backend/src/routes/registration.service.ts
+++ b/backend/src/routes/registration.service.ts
@@ -91,3 +91,7 @@ export async function getCredentialByRegId(registrationId: number) {
     return db.select().from(credentials).where(eq(credentials.registrationId, registrationId))
         .limit(1);
 }
+
+export async function getAllRegistrations() {
+    return db.select().from(registrations);
+}

--- a/backend/src/types/express-auth.d.ts
+++ b/backend/src/types/express-auth.d.ts
@@ -5,5 +5,6 @@ import "express";
 declare module "express-serve-static-core" {
     interface Request {
         registrationId?: number;
+        isOrganizer?: boolean;
     }
 }

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -6,6 +6,7 @@ import cookie from "cookie";
 
 interface Session {
     registrationId: number;
+    isOrganizer: boolean;
 }
 
 const SESSIONS = new Map<string, Session>();
@@ -30,9 +31,9 @@ export const requireProxySeal: RequestHandler = (req, res, next) => {
     next();
 };
 
-export function createSession(res: Response, registrationId: number) {
+export function createSession(res: Response, registrationId: number, isOrganizer = false) {
     const sid = crypto.randomBytes(16).toString("hex");
-    SESSIONS.set(sid, { registrationId });
+    SESSIONS.set(sid, { registrationId, isOrganizer });
     res.cookie("sessionid", sid, {
         httpOnly: true,
         secure: true,
@@ -51,5 +52,6 @@ export function requireAuth(req: Request, res: Response, next: NextFunction) {
     }
     // Expose to downstream
     (req as any).registrationId = sess.registrationId;
+    (req as any).isOrganizer = !!sess.isOrganizer;
     next();
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,8 @@
 
 import RegistrationPage from './features/registration/RegistrationPage';
 import HomePage from './features/home/HomePage';
+import AdministrationPage from './features/administration/AdministrationPage';
+import ListRegistrationsPage from './features/administration/ListRegistrationsPage';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import AppLayout from '@/components/layout/AppLayout';
 
@@ -23,6 +25,8 @@ const App = () => {
                         }
                     />
                     <Route path="/register" element={<RegistrationPage />} />
+                    <Route path="/administration" element={<AdministrationPage />} />
+                    <Route path="/registrations/list" element={<ListRegistrationsPage />} />
                 </Routes>
             </AppLayout>
         </BrowserRouter>

--- a/frontend/src/features/administration/AdministrationPage.tsx
+++ b/frontend/src/features/administration/AdministrationPage.tsx
@@ -1,0 +1,41 @@
+// frontend/src/features/administration/AdministrationPage.tsx
+
+import React from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type LocationState = { registration?: any };
+
+const AdministrationPage: React.FC = () => {
+    const navigate = useNavigate();
+    const { state } = useLocation();
+    const { registration } = (state as LocationState) || {};
+
+    const goUpdate = () => navigate("/register", { state: { registration } });
+    const goList = () => navigate("/registrations/list");
+
+    return (
+        <div className="space-y-4">
+            <header className="pb-2 mb-1">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
+                    <Link to="/home" className="flex items-center gap-1 text-primary hover:underline">
+                        <ArrowLeft className="h-4 w-4" />
+                        Home
+                    </Link>
+                    <h1 className="text-xl sm:text-2xl font-semibold text-center w-full">
+                        Administration Options
+                    </h1>
+                </div>
+            </header>
+
+            <div className="flex flex-col gap-2">
+                <Button onClick={goUpdate}>Update My Registration</Button>
+                <Button onClick={goList}>List Registrations</Button>
+            </div>
+        </div>
+    );
+};
+
+export default AdministrationPage;
+

--- a/frontend/src/features/administration/ListRegistrationsPage.tsx
+++ b/frontend/src/features/administration/ListRegistrationsPage.tsx
@@ -1,0 +1,125 @@
+// frontend/src/features/administration/ListRegistrationsPage.tsx
+
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { apiFetch } from "@/lib/api";
+import {
+    ColumnDef,
+    flexRender,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from "@tanstack/react-table";
+
+interface Registration {
+    id: number;
+    firstName?: string;
+    lastName?: string;
+    email: string;
+}
+
+const ListRegistrationsPage: React.FC = () => {
+    const [data, setData] = useState<Registration[]>([]);
+    const [globalFilter, setGlobalFilter] = useState("");
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        apiFetch("/api/registrations")
+            .then((d: any) => setData(d.registrations || []))
+            .catch((err: any) => {
+                alert(err?.data?.error || err.message || "Failed to load registrations");
+            });
+    }, []);
+
+    const columns = useMemo<ColumnDef<Registration>[]>(
+        () => [
+            { accessorKey: "id", header: "ID" },
+            { accessorKey: "firstName", header: "First Name" },
+            { accessorKey: "lastName", header: "Last Name" },
+            { accessorKey: "email", header: "Email" },
+            {
+                id: "actions",
+                header: "",
+                cell: ({ row }) => (
+                    <Button
+                        variant="link"
+                        onClick={() => navigate("/register", { state: { registration: row.original } })}
+                    >
+                        Edit
+                    </Button>
+                ),
+            },
+        ],
+        [navigate]
+    );
+
+    const table = useReactTable({
+        data,
+        columns,
+        state: { globalFilter },
+        onGlobalFilterChange: setGlobalFilter,
+        getCoreRowModel: getCoreRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+    });
+
+    return (
+        <div className="space-y-4">
+            <header className="pb-2 mb-1">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:gap-2">
+                    <Link to="/administration" className="flex items-center gap-1 text-primary hover:underline">
+                        <ArrowLeft className="h-4 w-4" />
+                        Home
+                    </Link>
+                    <h1 className="text-xl sm:text-2xl font-semibold text-center w-full">
+                        Registrations
+                    </h1>
+                </div>
+            </header>
+
+            <Input
+                placeholder="Filter..."
+                value={globalFilter}
+                onChange={(e) => setGlobalFilter(e.target.value)}
+                className="max-w-sm"
+            />
+
+            <table className="min-w-full border">
+                <thead>
+                    {table.getHeaderGroups().map((hg) => (
+                        <tr key={hg.id}>
+                            {hg.headers.map((header) => (
+                                <th
+                                    key={header.id}
+                                    className="border px-2 py-1 cursor-pointer select-none"
+                                    onClick={header.column.getToggleSortingHandler()}
+                                >
+                                    {flexRender(header.column.columnDef.header, header.getContext())}
+                                    {{ asc: " ↑", desc: " ↓" }[header.column.getIsSorted() as string] ?? null}
+                                </th>
+                            ))}
+                        </tr>
+                    ))}
+                </thead>
+                <tbody>
+                    {table.getRowModel().rows.map((row) => (
+                        <tr key={row.id} className="hover:bg-gray-50">
+                            {row.getVisibleCells().map((cell) => (
+                                <td key={cell.id} className="border px-2 py-1">
+                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default ListRegistrationsPage;
+

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -44,7 +44,11 @@ const HomePage: React.FC<HomePageProps> = ({ onSuccess }) => {
 
             // Only pass registration forward
             onSuccess({ registration }); // if you still need this callback elsewhere
-            navigate("/register", { state: { registration } });
+            if (registration.isOrganizer) {
+                navigate("/administration", { state: { registration } });
+            } else {
+                navigate("/register", { state: { registration } });
+            }
         } catch (err: any) {
             const msg =
                 (err?.data?.error as string) ||


### PR DESCRIPTION
## Summary
- Support organizer sessions and privileges
- Add administration dashboard and registration listing table
- Route organizers to administration options after login

## Testing
- `npm test` *(fails: Cannot find package '@/app' imported from backend tests)*
- `npm test -- --config backend/vitest.config.ts` *(no test files found)*
- `npm run typecheck`
- `npm run typecheck:node` *(fails: The specified path does not exist: 'tsconfig.node.json')*


------
https://chatgpt.com/codex/tasks/task_e_68be67717db08322aacf665bed508ddd