### PR TITLE
docs: update technologies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ See the docs folder for application documentation.
 - MariaDB – Relational database 
 - Nginx – Reverse proxy and static file serving
 - Node.js – Server-side runtime
-- React – Frontend UI library 
-- Tailwind CSS – Utility‑first CSS framework 
-- TanStack Query – Data fetching & state synchronization for React 
-- TypeScript – Static typing for both backend and frontend code 
-- Vite – Frontend build tool and dev server 
-- Vitest – Testing framework 
+- React – Frontend UI library
+- React Router – Client-side routing
+- Radix UI & shadcn/ui – Component library for accessible UI primitives
+- Tailwind CSS – Utility‑first CSS framework
+- TanStack Query – Data fetching & state synchronization for React
+- TanStack Table – Type-safe data tables for React
+- TypeScript – Static typing for both backend and frontend code
+- Vite – Frontend build tool and dev server
+- Vitest – Testing framework
 
 ## Requirements for macOS
 


### PR DESCRIPTION
## Summary
- document React Router, Radix UI & shadcn/ui, and TanStack Table usage

## Testing
- `npm test` (fails: Cannot find package '@/app' imported in backend tests)
- `cd frontend && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c107c639e0832297f9b3f258e8081d