### PR TITLE
chore: log outgoing api requests

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -57,6 +57,17 @@ export async function apiFetch(
         headers.set(headerToUse, tokenToSend);
     }
 
+    // Log the outgoing request details to aid debugging authentication issues
+    try {
+        console.debug("[apiFetch] request", {
+            path,
+            method,
+            headers: Object.fromEntries(headers.entries()),
+        });
+    } catch {
+        // ignore logging errors (e.g., Headers not iterable)
+    }
+
     const res = await fetch(path, {
         credentials: "include",
         ...opts,


### PR DESCRIPTION
## Summary
- log `apiFetch` request method and headers to help debug CSRF/cookie issues

## Testing
- `npm run test:ci` *(fails: Cannot find package '@/app' imported from backend tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a5d1ab6c8322b9819151d33b76e8