### PR TITLE
style admin table with yellow theme

### DIFF
--- a/frontend/src/features/administration/AdministrationPage.tsx
+++ b/frontend/src/features/administration/AdministrationPage.tsx
@@ -185,6 +185,7 @@ const AdministrationPage: React.FC = () => {
                                 <div className="flex flex-col gap-2 w-full px-4">
                                     {/* Boolean filter bar (reads/writes TanStack columnFilters directly) */}
                                     <div className="flex flex-wrap gap-2 items-center">
+                                        <span className="font-medium">Filters:</span>
                                         {booleanFieldNames.map((name) => {
                                             const enabled = state.table.getColumn(name)?.getFilterValue() === true;
                                             return (

--- a/frontend/src/features/administration/components/DataTable.tsx
+++ b/frontend/src/features/administration/components/DataTable.tsx
@@ -238,18 +238,18 @@ export function DataTable<T extends object>(props: DataTableProps<T>) {
             })}
 
             {/* Table */}
-            <div className="rounded-md border">
+            <div className="rounded-md border border-chart-4">
                 <Table>
                     <TableHeader>
                         {table.getHeaderGroups().map((hg) => (
-                            <TableRow key={hg.id}>
+                            <TableRow key={hg.id} className="bg-chart-4/40">
                                 {hg.headers.map((header) => {
                                     const canSort = header.column.getCanSort();
                                     const sorted = header.column.getIsSorted() as false | "asc" | "desc";
                                     return (
                                         <TableHead
                                             key={header.id}
-                                            className={canSort ? "cursor-pointer select-none" : ""}
+                                            className={(canSort ? "cursor-pointer select-none " : "") + "text-gray-900"}
                                             onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
                                         >
                                             <div className="flex items-center gap-1">
@@ -270,7 +270,7 @@ export function DataTable<T extends object>(props: DataTableProps<T>) {
                                 <TableRow
                                     key={row.id}
                                     data-state={row.getIsSelected() && "selected"}
-                                    className="hover:bg-muted/40"
+                                    className="even:bg-chart-4/10 hover:bg-chart-4/20 data-[state=selected]:bg-chart-4/30"
                                     onClick={() => (props.onRowClick ? onRowClick?.(row.original) : undefined)}
                                 >
                                     {row.getVisibleCells().map((cell) => (


### PR DESCRIPTION
## Summary
- apply project yellow palette to administration table
- label boolean filter row

## Testing
- `npm test` *(fails: Cannot find package '@/app' imported from backend tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c615ce55248322be821ace9a675721