### PR TITLE
feat: add admin registration edit route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 // frontend/src/App.tsx
 
 import RegistrationPage from './features/registration/RegistrationPage';
+import AdminRegistrationPage from './features/registration/AdminRegistrationPage';
 import HomePage from './features/home/HomePage';
 import AdministrationPage from './features/administration/AdministrationPage';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
@@ -24,6 +25,7 @@ const App = () => {
                     />
                     <Route path="/register" element={<RegistrationPage />} />
                     <Route path="/organizer" element={<AdministrationPage />} />
+                    <Route path="/admin/registrations/:id" element={<AdminRegistrationPage />} />
                 </Routes>
             </AppLayout>
         </BrowserRouter>

--- a/frontend/src/features/administration/AdministrationPage.tsx
+++ b/frontend/src/features/administration/AdministrationPage.tsx
@@ -217,6 +217,8 @@ const AdministrationPage: React.FC = () => {
                 <RegistrationForm
                     fields={registrationFormData}
                     initialData={initialDataForUpdate}
+                    forceAdmin
+                    showHeader={false}
                 />
             )}
         </div>

--- a/frontend/src/features/registration/AdminRegistrationPage.tsx
+++ b/frontend/src/features/registration/AdminRegistrationPage.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+import RegistrationForm from "./RegistrationForm";
+import { registrationFormData } from "@/data/registrationFormData";
+import { apiFetch } from "@/lib/api";
+
+const AdminRegistrationPage: React.FC = () => {
+    const { id } = useParams<{ id: string }>();
+    const [initialData, setInitialData] = useState<any | undefined>(undefined);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            if (!id) return;
+            try {
+                const data = await apiFetch(`/api/registrations/${id}`, { method: "GET" });
+                if (data?.registration) setInitialData(data.registration);
+            } catch {
+                setInitialData(undefined);
+            }
+        };
+        fetchData();
+    }, [id]);
+
+    return (
+        <RegistrationForm
+            fields={registrationFormData}
+            initialData={initialData}
+            forceAdmin
+            showHeader={false}
+        />
+    );
+};
+
+export default AdminRegistrationPage;

--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -55,9 +55,16 @@ const normalizeForSubmit = (src: Record<string, any>) => {
 type RegistrationFormProps = {
     fields: FormField[];
     initialData?: Record<string, any>;
+    forceAdmin?: boolean;
+    showHeader?: boolean;
 };
 
-const RegistrationForm: React.FC<RegistrationFormProps> = ({ fields, initialData }) => {
+const RegistrationForm: React.FC<RegistrationFormProps> = ({
+    fields,
+    initialData,
+    forceAdmin = false,
+    showHeader = true,
+}) => {
 
     // Reducer-backed form state
     const [state, dispatch] = useReducer(
@@ -83,8 +90,8 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ fields, initialData
 
     // Derived facts
     const hasUpdatePrivilege = useMemo(
-        () => userHasUpdatePrivilege(fields, initialData),
-        [fields, initialData]
+        () => forceAdmin || userHasUpdatePrivilege(fields, initialData),
+        [fields, initialData, forceAdmin]
     );
 
     const proxyDataPresent = useMemo(
@@ -305,7 +312,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({ fields, initialData
 
     return (
         <form onSubmit={handleSubmit} noValidate className="space-y-4">
-            <PageHeader title={PAGE_TITLE}/>
+            {showHeader && <PageHeader title={PAGE_TITLE} />}
 
             {fieldsForRender.map((field) => {
                 let hr = null;


### PR DESCRIPTION
## Summary
- add dedicated admin registration edit page and route
- allow RegistrationForm to hide header and force admin privileges
- prevent duplicate heading when editing registration from admin page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c61ddd69848322b8db2f48c8483743