### PR TITLE
feat: allow default column visibility toggle

### DIFF
--- a/frontend/src/data/registrationFormData.ts
+++ b/frontend/src/data/registrationFormData.ts
@@ -27,6 +27,7 @@ export interface FormField {
     priv?: 'update';
     readOnly?: boolean;
     list?: boolean;
+    clickedByDefault?: boolean;
 }
 
 // Export a typed constant for each form element type.
@@ -36,6 +37,7 @@ export const registrationFormData: FormField[] = [
         label: 'You will be able to use your email address and the provided Pin if you need to update your registration information.',
         type: 'section',
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'email',
@@ -43,6 +45,7 @@ export const registrationFormData: FormField[] = [
         type: 'email',
         required: true,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'loginPin',
@@ -50,12 +53,14 @@ export const registrationFormData: FormField[] = [
         type: 'pin',
         readOnly: true,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'section-info',
         label: 'Provide your (attendee) contact information.',
         type: 'section',
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'phone1',
@@ -63,6 +68,7 @@ export const registrationFormData: FormField[] = [
         type: 'phone',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'phone2',
@@ -70,6 +76,7 @@ export const registrationFormData: FormField[] = [
         type: 'phone',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'firstName',
@@ -77,6 +84,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'lastName',
@@ -84,6 +92,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: true,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'namePrefix',
@@ -91,6 +100,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'nameSuffix',
@@ -98,6 +108,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'day1Attendee',
@@ -105,6 +116,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'day2Attendee',
@@ -112,6 +124,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'question1',
@@ -119,6 +132,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: true,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'question2',
@@ -126,12 +140,14 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: true,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'section-cancel',
         label: 'If you need to cancel, please return to this form to let us know.',
         type: 'section',
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'cancelledAttendance',
@@ -139,6 +155,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'cancellationReason',
@@ -146,6 +163,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'section-proxy',
@@ -153,6 +171,7 @@ export const registrationFormData: FormField[] = [
         type: 'section',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'hasProxy',
@@ -160,6 +179,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'proxyName',
@@ -167,6 +187,7 @@ export const registrationFormData: FormField[] = [
         type: 'text',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'proxyPhone',
@@ -174,6 +195,7 @@ export const registrationFormData: FormField[] = [
         type: 'phone',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'proxyEmail',
@@ -181,18 +203,21 @@ export const registrationFormData: FormField[] = [
         type: 'email',
         required: false,
         scope: 'registration',
+        clickedByDefault: true,
     },
     {
         name: 'section-roles',
         label: 'For internal use: indicate additional attendee roles.',
         type: 'section',
         scope: 'admin',
+        clickedByDefault: true,
     },
     {
         name: 'id',
         label: 'Registration Form ID',
         type: 'number',
         scope: 'admin',
+        clickedByDefault: true,
     },
     {
         name: 'isAttendee',
@@ -200,6 +225,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        clickedByDefault: true,
     },
     {
         name: 'isMonitor',
@@ -207,6 +233,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        clickedByDefault: true,
         priv: 'update',
     },
     {
@@ -215,6 +242,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        clickedByDefault: true,
         priv: 'update',
     },
     {
@@ -223,6 +251,7 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        clickedByDefault: true,
     },
     {
         name: 'isSponsor',
@@ -230,5 +259,6 @@ export const registrationFormData: FormField[] = [
         type: 'checkbox',
         required: false,
         scope: 'admin',
+        clickedByDefault: true,
     },
 ];

--- a/frontend/src/features/administration/components/DataTable.tsx
+++ b/frontend/src/features/administration/components/DataTable.tsx
@@ -86,7 +86,21 @@ export function DataTable<T extends object>(props: DataTableProps<T>) {
     // table state
     const [sorting, setSorting] = useState<SortingState>([]);
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
-    const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+    const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() => {
+        const initial: VisibilityState = {};
+        const collect = (cols: ColumnDef<T, any>[] | undefined) => {
+            cols?.forEach((col) => {
+                const id = (col as any).id ?? (col as any).accessorKey;
+                const meta = (col as any).meta as { clickedByDefault?: boolean } | undefined;
+                if (id && meta?.clickedByDefault !== true) {
+                    initial[id as string] = false;
+                }
+                if ((col as any).columns) collect((col as any).columns);
+            });
+        };
+        collect(columns);
+        return initial;
+    });
     const [pagination, setPagination] = useState<PaginationState>({
         pageIndex: 0,
         pageSize: defaultPageSize,

--- a/frontend/src/features/administration/table/columns.ts
+++ b/frontend/src/features/administration/table/columns.ts
@@ -49,6 +49,9 @@ export function buildListColumnsFromForm<T extends RegistrationIndexable>(
                     const v = getValue<any>();
                     return v == null ? "" : String(v);
                 },
+                meta: {
+                    clickedByDefault: f.clickedByDefault === true,
+                },
             } as ColumnDef<T>;
         });
 }


### PR DESCRIPTION
## Summary
- add `clickedByDefault` flag to registration form fields
- plumb flag through columns meta and use it to initialize table column visibility
- treat omitted `clickedByDefault` values as hidden by default

## Testing
- `npm test -- --run` (fails: Cannot find package '@/routes/registration')
- `npm run build` (fails: The specified path does not exist: 'tsconfig.node.json')

------
https://chatgpt.com/codex/tasks/task_e_68c6f5bba7ec8322af837ed49e25a465