### PR TITLE
Refine admin organizer tabs layout

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -4,9 +4,7 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 
 import PageHeading from '@/components/ui/PageHeading';
-import SubPageHeading from '@/components/ui/SubPageHeading';
 import PageFooter from '@/components/ui/PageFooter';
-import AdminTabs from '@/components/ui/AdminTabs';
 
 type AppLayoutProps = {
     children: React.ReactNode;
@@ -14,17 +12,18 @@ type AppLayoutProps = {
 
 const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
     const location = useLocation();
-    const isHome = location.pathname === '/home' || location.pathname === '/';
     const isAdmin = location.pathname === '/organizer';
 
     return (
         <div className="min-h-screen bg-background text-foreground flex flex-col">
             <PageHeading />
-            <SubPageHeading showHomeLink={!isHome} />
-            {isAdmin && <AdminTabs />}
 
             <main className="flex-1 w-full">
-                <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-8 sm:py-10">{children}</div>
+                {isAdmin ? (
+                    children
+                ) : (
+                    <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-8 sm:py-10">{children}</div>
+                )}
             </main>
 
             <PageFooter />

--- a/frontend/src/components/ui/AdminTabs.tsx
+++ b/frontend/src/components/ui/AdminTabs.tsx
@@ -1,43 +1,61 @@
 import React from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
-const AdminTabs: React.FC = () => {
-    const [searchParams, setSearchParams] = useSearchParams();
-    const activeTab = searchParams.get('tab') === 'update' ? 'update' : 'list';
+import { cn } from '@/lib/utils';
 
-    const handleSelect = (tab: 'list' | 'update') => {
-        if (activeTab === tab) return;
-        const next = new URLSearchParams(searchParams);
-        next.set('tab', tab);
-        setSearchParams(next, { replace: true });
-    };
+type AdminTabsProps = {
+    activeTab: 'list' | 'update';
+    onSelect: (tab: 'list' | 'update') => void;
+    canViewList?: boolean;
+};
+
+const AdminTabs: React.FC<AdminTabsProps> = ({ activeTab, onSelect, canViewList = true }) => {
+    const navigate = useNavigate();
+    const location = useLocation();
+
+    const handleHome = () => navigate('/home');
+    const handleForm = () => onSelect('update');
+    const handleList = () => onSelect('list');
+
+    const homeActive = location.pathname === '/home';
 
     return (
         <div className="w-full border-b bg-card">
-            <div className="mx-auto w-full max-w-5xl px-4 sm:px-8">
+            <div className="mx-auto w-[98vw] px-4 py-2 sm:px-6">
                 <div className="admin-tabs" role="tablist" aria-label="Administration tabs">
                     <button
-                        role="tab"
-                        aria-selected={activeTab === 'list'}
-                        aria-controls="tab-panel-list"
-                        id="tab-list"
-                        className={`admin-tab ${activeTab === 'list' ? 'admin-tab--active' : ''}`}
-                        onClick={() => handleSelect('list')}
                         type="button"
+                        role="tab"
+                        aria-selected={homeActive}
+                        className={cn('admin-tab', homeActive && 'admin-tab--active')}
+                        onClick={handleHome}
                     >
-                        List Registrations
+                        Home
                     </button>
                     <button
+                        type="button"
                         role="tab"
                         aria-selected={activeTab === 'update'}
                         aria-controls="tab-panel-update"
                         id="tab-update"
-                        className={`admin-tab ${activeTab === 'update' ? 'admin-tab--active' : ''}`}
-                        onClick={() => handleSelect('update')}
-                        type="button"
+                        className={cn('admin-tab', activeTab === 'update' && 'admin-tab--active')}
+                        onClick={handleForm}
                     >
-                        Update Registration
+                        Registration Form
                     </button>
+                    {canViewList && (
+                        <button
+                            type="button"
+                            role="tab"
+                            aria-selected={activeTab === 'list'}
+                            aria-controls="tab-panel-list"
+                            id="tab-list"
+                            className={cn('admin-tab', activeTab === 'list' && 'admin-tab--active')}
+                            onClick={handleList}
+                        >
+                            Registrations Table
+                        </button>
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/src/components/ui/TabContent.tsx
+++ b/frontend/src/components/ui/TabContent.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+type TabContentProps = {
+    children: React.ReactNode;
+    className?: string;
+};
+
+const TabContent: React.FC<TabContentProps> = ({ children, className }) => {
+    return (
+        <div className="w-full bg-muted/40 py-6">
+            <div className="mx-auto w-[98vw] px-4 sm:px-6">
+                <div className={cn('tab-content-card', className)}>{children}</div>
+            </div>
+        </div>
+    );
+};
+
+export default TabContent;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -104,9 +104,8 @@ hr {
 
 /* ---------- Components ---------- */
 @layer components {
-    /* Card shell */
-    .page-card {
-        @apply mx-auto w-full max-w-6xl bg-white rounded-xl shadow-lg p-6;
+    .tab-content-card {
+        @apply w-full bg-white rounded-xl shadow-lg border border-neutral-200 p-6;
     }
 
     /* Tabs */


### PR DESCRIPTION
## Summary
- replace the organizer page card with a reusable `TabContent` shell that spans 98% width and applies the registration form shadow treatment
- move the organizer navigation tabs into the page with a new Home tab and conditional table tab, keeping the registration form tab available to every user
- simplify the application layout by dropping the sub page heading wrapper so the admin view can render its own tab content row
- align the TabContent padding with the tabs row so each row shares the same 98% width gutter
- rename the tab panel heading to "Registration Form" per review feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d87d20d80c8322b8b996d67909e49a