### PR TITLE
Ensure admin tab visibility persists for organizers

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ const AppRoutes: React.FC = () => {
 
             try {
                 sessionStorage.setItem('regId', String(registration.id ?? ''));
+                sessionStorage.setItem('regIsOrganizer', registration.isOrganizer ? 'true' : 'false');
             } catch {
                 /* ignore sessionStorage failures */
             }

--- a/frontend/src/features/administration/AdministrationPage.tsx
+++ b/frontend/src/features/administration/AdministrationPage.tsx
@@ -53,11 +53,22 @@ const AdministrationPage: React.FC = () => {
     const { data: registrations, isLoading, error } = useRegistrations();
 
     const storedId = Number(sessionStorage.getItem("regId") ?? "");
+    const storedOrganizerFlag = useMemo<boolean | undefined>(() => {
+        try {
+            const raw = sessionStorage.getItem("regIsOrganizer");
+            if (raw === null) return undefined;
+            if (raw === "true" || raw === "1") return true;
+            if (raw === "false" || raw === "0") return false;
+            return undefined;
+        } catch {
+            return undefined;
+        }
+    }, []);
     const idFromState = registration?.id ?? (Number.isNaN(storedId) ? null : storedId);
     const { data: fetchedById } = useRegistrationById(idFromState);
 
     const initialDataForUpdate = selected ?? fetchedById ?? registration;
-    const canViewList = Boolean(registration?.isOrganizer ?? fetchedById?.isOrganizer);
+    const canViewList = Boolean(registration?.isOrganizer ?? storedOrganizerFlag);
 
     useEffect(() => {
         if (!canViewList && activeTab === "list") {


### PR DESCRIPTION
## Summary
- store the organizer role in session storage when a user logs in
- rely on the stored organizer flag so the admin registrations tab stays available while editing any record

## Testing
- npm run test *(fails: vitest cannot resolve backend path aliases in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8859d89f88322854067c10bbb259b