### PR TITLE
Expose TLS on 8443 via docker-compose mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,12 +83,12 @@ init-backend: ## Rebuild and restart backend + proxy (current profile)
 	$(ECHO_PROFILE)
 	$(COMPOSE) build --no-cache $(SERVICE_BACKEND)
 	$(COMPOSE) up -d $(SERVICE_DB) $(SERVICE_BACKEND) $(SERVICE_PROXY)
-	@echo "Backend reachable via nginx at: https://localhost:8080"
+@echo "Backend reachable via nginx at: https://localhost:8443"
 
 up-backend: ## Start db + backend + proxy (no UI container)
 	$(ECHO_PROFILE)
 	$(COMPOSE) up -d $(SERVICE_DB) $(SERVICE_BACKEND) $(SERVICE_PROXY)
-	@echo "Backend up at: https://localhost:8080"
+@echo "Backend up at: https://localhost:8443"
 
 backend-shell: ## Open a shell in the backend container (current profile)
 	$(ECHO_PROFILE)
@@ -202,7 +202,7 @@ build-nocache: ## Build Docker images without cache (current profile/env)
 up: ## Start containers in detached mode (current profile/env)
 	$(ECHO_PROFILE)
 	$(COMPOSE) up -d
-	@echo "Running: https://localhost:8080/"
+@echo "Running: https://localhost:8443/"
 
 down: ## Stop and remove containers (current profile/env)
 	$(ECHO_PROFILE)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See the docs folder for application documentation.
 
 ## Developer Notes
 
-- Frontend: <https://localhost:8080/>
+- Frontend: <https://localhost:8443/>
 - Makefile commands honor the `ENV_PROFILE` variable. Set `ENV_PROFILE=prod` to run against the production profile.
 - Command `make ensure-drizzle-deps` updates Drizzle.
 - TLS certificates are stored in `backend/certs` and are mounted into the backend container.
@@ -306,7 +306,7 @@ To confirm everything is working, try:
 make init
 ```
 
-Then visit: [https://localhost:8080](https://localhost:8080)
+Then visit: [https://localhost:8443](https://localhost:8443)
 
 ---
 # Future work

--- a/backend/tests/csrf.spec.ts
+++ b/backend/tests/csrf.spec.ts
@@ -4,7 +4,7 @@ import request from 'supertest';
 import { describe, it, expect } from 'vitest';
 import app from '@/app';
 
-const ORIGIN = process.env.UI_ORIGIN || 'https://localhost:8080';
+const ORIGIN = process.env.UI_ORIGIN || 'https://localhost:8443';
 const SEAL = process.env.INTERNAL_SECRET || 'test-secret';
 
 describe('CSRF flow', () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   proxy:
     image: nginx:alpine
     ports:
-      - "8080:8080"
+      - "8443:8080"
     environment:
       INTERNAL_SECRET: ${INTERNAL_SECRET}
       # tell nginx where the template is and where to write the rendered config

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(({ command }) => {
                 // omit "https" so Vite serves HTTP by default
                 proxy: {
                     '/api': {
-                        target: 'https://localhost:8080', // nginx is TLS on 8080
+                        target: 'https://localhost:8443', // nginx is TLS on 8443
                         changeOrigin: true,
                         secure: false, // accept self-signed
                     },

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -39,7 +39,7 @@ http {
     server_name _;
 
     # If HTTP hits the HTTPS listener (Nginx logs 497), redirect to https
-    error_page 497 =301 https://$host:8080$request_uri;
+    error_page 497 =301 https://$host:8443$request_uri;
 
     ssl_certificate     /etc/nginx/certs/localhost.pem;
     ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
@@ -65,7 +65,7 @@ http {
       proxy_pass http://conference_backend;     # ⬅️ back to HTTP
       proxy_set_header X-Internal-Secret "${INTERNAL_SECRET}";
 
-      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_set_header X-Forwarded-Port 8443;
       proxy_set_header X-Forwarded-Proto $scheme;
     }
 


### PR DESCRIPTION
## Summary
- map the proxy service to publish 8443 externally while keeping nginx TLS on port 8080
- update nginx forwarding metadata so backend logic still observes requests as coming from 8443

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8bb153b548322a0a89bc38c8be517