### PR TITLE
Add admin attendee creation and lunch menu validation select

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,8 @@ import compression from "compression";
 import cors from "cors";
 import cookieParser from "cookie-parser";
 import registrationRoutes from "./routes/registration";
+import sessionRoutes from "./routes/session";
+import validationTableRoutes from "./routes/validationTables";
 import {errorLogger, requestLogger} from "@/utils/logger";
 import {requireProxySeal} from "@/utils/auth";
 
@@ -45,6 +47,8 @@ app.use(helmet({
 
 // 3) API routes
 app.use("/api/registrations", registrationRoutes);
+app.use("/api/session", sessionRoutes);
+app.use("/api/validation-tables", validationTableRoutes);
 
 // 4) Error logging
 app.use(errorLogger());

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -42,6 +42,7 @@ export const registrations = mysqlTable('registrations', {
     // Registration information
     day1Attendee: boolean('day1_attendee').default(false),
     day2Attendee: boolean('day2_attendee').default(false),
+    lunchMenu: varchar('lunch_menu', {length: 128}),
     question1: varchar('question1', {length: 128}).notNull(),
     question2: varchar('question2', {length: 128}).notNull(),
     isCancelled: boolean('is_cancelled').default(false),

--- a/backend/src/routes/session.ts
+++ b/backend/src/routes/session.ts
@@ -1,0 +1,21 @@
+// backend/src/routes/session.ts
+
+import {Router, Request, Response} from "express";
+import {clearSession, getSession} from "@/utils/auth";
+import {log} from "@/utils/logger";
+
+const router = Router();
+
+router.post("/logout", (req: Request, res: Response) => {
+    const session = getSession(req);
+    if (session) {
+        log.info("Session destroyed", {
+            registrationId: session.registrationId,
+            isOrganizer: session.isOrganizer,
+        });
+    }
+    clearSession(req, res);
+    res.json({ ok: true });
+});
+
+export default router;

--- a/backend/src/routes/validationTables.ts
+++ b/backend/src/routes/validationTables.ts
@@ -1,0 +1,39 @@
+// backend/src/routes/validationTables.ts
+
+import {Request, Response, Router} from "express";
+import {asc, eq} from "drizzle-orm";
+
+import {db} from "@/db/client";
+import {validationTables} from "@/db/schema";
+import {log, sendError} from "@/utils/logger";
+import {logDbError} from "@/utils/dbErrorLogger";
+
+const router = Router();
+
+router.get("/:table", async (req: Request, res: Response) => {
+    const table = String(req.params.table ?? "").trim();
+    if (!table) {
+        sendError(res, 400, "validation_table_required");
+        return;
+    }
+
+    try {
+        const rows = await db
+            .select()
+            .from(validationTables)
+            .where(eq(validationTables.validationTable, table))
+            .orderBy(asc(validationTables.value));
+
+        res.json({
+            values: rows.map((row) => row.value),
+        });
+    } catch (err) {
+        logDbError(log, err, {
+            message: "Failed to load validation table",
+            table,
+        });
+        sendError(res, 500, "Failed to load validation table");
+    }
+});
+
+export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import AdminRegistrationPage from './features/registration/AdminRegistrationPage
 import HomePage from './features/home/HomePage';
 import AdministrationPage from './features/administration/AdministrationPage';
 import AppLayout from '@/components/layout/AppLayout';
+import { AuthProvider, useAuth } from './features/auth/AuthContext';
 
 type LoginSuccessPayload = {
     registration?: any;
@@ -15,22 +16,18 @@ type LoginSuccessPayload = {
 
 const AppRoutes: React.FC = () => {
     const navigate = useNavigate();
+    const { login } = useAuth();
 
     const handleLoginSuccess = useCallback(
         ({ registration }: LoginSuccessPayload) => {
             if (!registration) return;
 
-            try {
-                sessionStorage.setItem('regId', String(registration.id ?? ''));
-                sessionStorage.setItem('regIsOrganizer', registration.isOrganizer ? 'true' : 'false');
-            } catch {
-                /* ignore sessionStorage failures */
-            }
+            login(registration);
 
             const target = registration.isOrganizer ? '/organizer' : '/register';
             navigate(target, { state: { registration } });
         },
-        [navigate],
+        [login, navigate],
     );
 
     return (
@@ -47,9 +44,11 @@ const AppRoutes: React.FC = () => {
 const App: React.FC = () => {
     return (
         <BrowserRouter>
-            <AppLayout>
-                <AppRoutes />
-            </AppLayout>
+            <AuthProvider>
+                <AppLayout>
+                    <AppRoutes />
+                </AppLayout>
+            </AuthProvider>
         </BrowserRouter>
     );
 };

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -1,6 +1,17 @@
 import React from 'react';
+import { useAuth } from '@/features/auth/AuthContext';
 
 const PageHeader: React.FC = () => {
+    const { registration } = useAuth();
+    const firstName = typeof registration?.firstName === 'string' ? registration.firstName.trim() : '';
+    const lastName = typeof registration?.lastName === 'string' ? registration.lastName.trim() : '';
+    const hasName = firstName !== '' || lastName !== '';
+    const message = registration
+        ? hasName
+            ? `Welcome ${[firstName, lastName].filter(Boolean).join(' ')}`
+            : 'Welcome'
+        : 'Invitation-only access';
+
     return (
         <div
             className="w-full bg-cover bg-center"
@@ -12,7 +23,7 @@ const PageHeader: React.FC = () => {
                         Conference Registration
                     </h1>
                     <p className="mt-2 text-sm font-medium text-white/90 sm:text-base">
-                        Invitation-only access
+                        {message}
                     </p>
                 </div>
             </div>

--- a/frontend/src/components/ui/validation-table-select.tsx
+++ b/frontend/src/components/ui/validation-table-select.tsx
@@ -1,0 +1,70 @@
+// frontend/src/components/ui/validation-table-select.tsx
+
+import React from 'react';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+
+export type ValidationTableSelectProps = {
+    id?: string;
+    value?: string | null;
+    options: string[];
+    onChange: (value: string | null) => void;
+    placeholder?: string;
+    disabled?: boolean;
+    allowClear?: boolean;
+    isLoading?: boolean;
+    'aria-invalid'?: boolean;
+    'aria-describedby'?: string;
+    className?: string;
+};
+
+export const ValidationTableSelect: React.FC<ValidationTableSelectProps> = ({
+    id,
+    value,
+    options,
+    onChange,
+    placeholder = 'Select an option',
+    disabled = false,
+    allowClear = false,
+    isLoading = false,
+    className,
+    ...ariaProps
+}) => {
+    const normalizedValue = value ?? '';
+    const resolvedPlaceholder = isLoading ? 'Loading…' : placeholder;
+
+    return (
+        <Select
+            value={normalizedValue}
+            onValueChange={(next) => onChange(next === '' ? null : next)}
+            disabled={disabled || isLoading}
+        >
+            <SelectTrigger id={id} className={className ?? 'w-full'} {...ariaProps}>
+                <SelectValue placeholder={resolvedPlaceholder} />
+            </SelectTrigger>
+            <SelectContent>
+                {allowClear && (
+                    <SelectItem value="">
+                        None
+                    </SelectItem>
+                )}
+                {options.length === 0 ? (
+                    <SelectItem value="__empty" disabled>
+                        {isLoading ? 'Loading…' : 'No options available'}
+                    </SelectItem>
+                ) : (
+                    options.map((option) => (
+                        <SelectItem key={option} value={option}>
+                            {option}
+                        </SelectItem>
+                    ))
+                )}
+            </SelectContent>
+        </Select>
+    );
+};

--- a/frontend/src/data/registrationFormData.ts
+++ b/frontend/src/data/registrationFormData.ts
@@ -24,13 +24,14 @@
 export interface FormField {
     name: string;
     label: string;
-    type: 'text' | 'email' | 'phone' | 'checkbox' | 'number' | 'section';
+    type: 'text' | 'email' | 'phone' | 'checkbox' | 'number' | 'section' | 'validation-table';
     required?: boolean;
     scope: 'admin' | 'registration';
     priv?: 'update';
     readOnly?: boolean;
     list?: boolean;
     clickedByDefault?: boolean;
+    validationTable?: string;
 }
 
 // Export a typed constant for each form element type.
@@ -116,6 +117,14 @@ export const registrationFormData: FormField[] = [
         required: false,
         scope: 'registration',
         clickedByDefault: true,
+    },
+    {
+        name: 'lunchMenu',
+        label: 'Lunch Menu',
+        type: 'validation-table',
+        required: false,
+        scope: 'registration',
+        validationTable: 'lunch-menu',
     },
     {
         name: 'question1',

--- a/frontend/src/features/administration/hooks/useRegistrationById.ts
+++ b/frontend/src/features/administration/hooks/useRegistrationById.ts
@@ -8,17 +8,20 @@ export function useRegistrationById(id?: number | null) {
     const [data, setData] = useState<Registration | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [error, setError] = useState<string | null>(null);
+    const [errorStatus, setErrorStatus] = useState<number | null>(null);
 
     const load = useCallback(async () => {
         if (!id) return;
         setIsLoading(true);
         setError(null);
+        setErrorStatus(null);
         try {
             const res = await apiFetch(`/api/registrations/${id}`, { method: "GET" });
             setData(res?.registration ?? null);
         } catch (e: any) {
             const msg = e?.data?.error || e?.message || "Failed to load registration";
             setError(msg);
+            setErrorStatus(typeof e?.status === "number" ? e.status : null);
         } finally {
             setIsLoading(false);
         }
@@ -28,5 +31,5 @@ export function useRegistrationById(id?: number | null) {
         void load();
     }, [load]);
 
-    return { data, setData, isLoading, error, reload: load };
+    return { data, setData, isLoading, error, errorStatus, reload: load };
 }

--- a/frontend/src/features/administration/hooks/useRegistrations.ts
+++ b/frontend/src/features/administration/hooks/useRegistrations.ts
@@ -17,16 +17,19 @@ export function useRegistrations() {
     const [data, setData] = useState<Registration[]>([]);
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [error, setError] = useState<string | null>(null);
+    const [errorStatus, setErrorStatus] = useState<number | null>(null);
 
     const load = useCallback(async () => {
         setIsLoading(true);
         setError(null);
+        setErrorStatus(null);
         try {
             const res = await apiFetch("/api/registrations");
             setData(res?.registrations ?? []);
         } catch (e: any) {
             const msg = e?.data?.error || e?.message || "Failed to load registrations";
             setError(msg);
+            setErrorStatus(typeof e?.status === "number" ? e.status : null);
         } finally {
             setIsLoading(false);
         }
@@ -45,7 +48,7 @@ export function useRegistrations() {
     );
 
     return useMemo(
-        () => ({ data, setData, isLoading, error, reload, byId }),
-        [data, isLoading, error, reload, byId]
+        () => ({ data, setData, isLoading, error, errorStatus, reload, byId }),
+        [data, isLoading, error, errorStatus, reload, byId]
     );
 }

--- a/frontend/src/features/auth/AuthContext.tsx
+++ b/frontend/src/features/auth/AuthContext.tsx
@@ -1,0 +1,123 @@
+// frontend/src/features/auth/AuthContext.tsx
+
+import React, {createContext, useCallback, useContext, useEffect, useMemo, useState} from "react";
+import {apiFetch, clearCsrf} from "@/lib/api";
+
+export interface AuthContextValue {
+    registration: Record<string, any> | null;
+    isOrganizer: boolean;
+    loading: boolean;
+    login: (registration: Record<string, any>) => void;
+    logout: () => Promise<void>;
+    refresh: () => Promise<void>;
+    setRegistration: (registration: Record<string, any> | null) => void;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+function safeGetSessionId(): number | null {
+    try {
+        const raw = sessionStorage.getItem("regId");
+        if (!raw) return null;
+        const parsed = Number(raw);
+        return Number.isNaN(parsed) ? null : parsed;
+    } catch {
+        return null;
+    }
+}
+
+function persistRegistration(registration: Record<string, any> | null) {
+    try {
+        if (registration && registration.id != null) {
+            sessionStorage.setItem("regId", String(registration.id));
+            sessionStorage.setItem(
+                "regIsOrganizer",
+                registration.isOrganizer ? "true" : "false"
+            );
+        } else {
+            sessionStorage.removeItem("regId");
+            sessionStorage.removeItem("regIsOrganizer");
+        }
+    } catch {
+        // Ignore storage errors (e.g., Safari private mode)
+    }
+}
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [registration, setRegistrationState] = useState<Record<string, any> | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+
+    const applyRegistration = useCallback((reg: Record<string, any> | null) => {
+        setRegistrationState(reg);
+        persistRegistration(reg);
+    }, []);
+
+    const refresh = useCallback(async () => {
+        setLoading(true);
+        const sessionId = safeGetSessionId();
+        if (!sessionId) {
+            applyRegistration(null);
+            setLoading(false);
+            return;
+        }
+
+        try {
+            const data = await apiFetch(`/api/registrations/${sessionId}`, { method: "GET" });
+            if (data?.registration) {
+                applyRegistration(data.registration);
+            } else {
+                applyRegistration(null);
+            }
+        } catch {
+            applyRegistration(null);
+        } finally {
+            setLoading(false);
+        }
+    }, [applyRegistration]);
+
+    useEffect(() => {
+        void refresh();
+    }, [refresh]);
+
+    const login = useCallback(
+        (reg: Record<string, any>) => {
+            applyRegistration(reg);
+            setLoading(false);
+        },
+        [applyRegistration]
+    );
+
+    const logout = useCallback(async () => {
+        try {
+            await apiFetch("/api/session/logout", { method: "POST" });
+        } catch {
+            // Ignore logout errors; we'll clear client state regardless.
+        }
+        clearCsrf();
+        applyRegistration(null);
+        setLoading(false);
+    }, [applyRegistration]);
+
+    const value = useMemo<AuthContextValue>(
+        () => ({
+            registration,
+            isOrganizer: Boolean(registration?.isOrganizer),
+            loading,
+            login,
+            logout,
+            refresh,
+            setRegistration: applyRegistration,
+        }),
+        [registration, loading, login, logout, refresh, applyRegistration]
+    );
+
+    return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export function useAuth(): AuthContextValue {
+    const ctx = useContext(AuthContext);
+    if (!ctx) {
+        throw new Error("useAuth must be used within an AuthProvider");
+    }
+    return ctx;
+}


### PR DESCRIPTION
## Summary
- add an authentication context to share session state across the SPA, update the header greeting, and turn the admin home tab into a logout action
- expose validation table and logout APIs, persist lunch menu selections, and surface a reusable validation-table select field with a new Lunch Menu form input
- let organizers create blank registrations from the list view with a + Attendee button and refresh the table after saves

## Testing
- npm run build (frontend)
- npm run build (backend)

------
https://chatgpt.com/codex/tasks/task_e_68d9785a75608322a997f197e6843ddf