### PR TITLE
Handle missing validation table options gracefully

### DIFF
--- a/frontend/src/features/registration/FieldFactory.tsx
+++ b/frontend/src/features/registration/FieldFactory.tsx
@@ -101,7 +101,6 @@ export function FieldRenderer({ field, state, isMissing, onCheckboxChange, onInp
                     onChange={(val) => onValueChange(field.name, val)}
                     allowClear={!field.required}
                     isLoading={isLoading}
-                    disabled={!isLoading && options.length === 0}
                     placeholder="Select an option"
                     aria-invalid={hasAnyError}
                     aria-describedby={describedBy}

--- a/frontend/src/hooks/useValidationTableOptions.ts
+++ b/frontend/src/hooks/useValidationTableOptions.ts
@@ -17,7 +17,8 @@ export function useValidationTableOptions(table?: string): ValidationTableState 
     useEffect(() => {
         if (!table) {
             setOptions([]);
-            setError('Missing validation table');
+            setError(null);
+            setLoading(false);
             return;
         }
 
@@ -40,9 +41,17 @@ export function useValidationTableOptions(table?: string): ValidationTableState 
                 setOptions(values);
             } catch (err: any) {
                 if (cancelled) return;
-                const message = err?.data?.error || err?.message || 'Failed to load options';
-                setError(message);
-                setOptions([]);
+                const status: number | undefined = typeof err?.status === 'number' ? err.status : undefined;
+                const code = err?.data?.error;
+
+                if (status === 404 || code === 'validation_table_not_found') {
+                    setOptions([]);
+                    setError(null);
+                } else {
+                    const message = code || err?.message || 'Failed to load options';
+                    setError(message);
+                    setOptions([]);
+                }
             } finally {
                 if (!cancelled) setLoading(false);
             }


### PR DESCRIPTION
## Summary
- prevent validation-table fields from surfacing errors when their backing table is missing by treating missing tables as empty option lists
- keep the dropdown enabled so it simply shows an empty list instead of a disabled control

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68d9ba2d9bd48322bb2415db1129cdae