### PR TITLE
Fix React Query configuration typing issues

### DIFF
--- a/frontend/src/features/registration/PresenterPhotoField.tsx
+++ b/frontend/src/features/registration/PresenterPhotoField.tsx
@@ -39,9 +39,9 @@ export function PresenterPhotoField({ field, value, onChange, isMissing, error }
     const [dialogMessage, setDialogMessage] = useState<string | null>(null);
     const [cacheBuster, setCacheBuster] = useState<number>(Date.now());
     const inputRef = useRef<HTMLInputElement | null>(null);
-    const { data: appConfig } = useAppConfig();
+    const { data: appConfigData } = useAppConfig();
 
-    const maxFileBytes = appConfig?.presenterMaxBytes ?? DEFAULT_MAX_FILE_BYTES;
+    const maxFileBytes = appConfigData?.presenterMaxBytes ?? DEFAULT_MAX_FILE_BYTES;
     const maxFileReadable = useMemo(() => formatBytes(maxFileBytes), [maxFileBytes]);
 
     const showErrorStyle = isMissing || Boolean(error);

--- a/frontend/src/hooks/useAppConfig.ts
+++ b/frontend/src/hooks/useAppConfig.ts
@@ -17,11 +17,11 @@ async function fetchAppConfig(): Promise<AppConfig> {
 }
 
 export function useAppConfig() {
-    return useQuery<AppConfig>({
+    return useQuery<AppConfig, Error, AppConfig, ['appConfig']>({
         queryKey: ['appConfig'],
         queryFn: fetchAppConfig,
         staleTime: Infinity,
-        cacheTime: Infinity,
+        gcTime: Infinity,
     });
 }
 


### PR DESCRIPTION
## Summary
- use the React Query v5 `gcTime` option instead of the removed `cacheTime`
- tighten the `useAppConfig` hook generics so the config shape is preserved in consumers
- adjust the presenter photo field to read the renamed config data variable

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e1ce5cb27c8322848d775a5f6bf678