### PR TITLE
Add presenter placeholder image

### DIFF
--- a/frontend/src/assets/presenter-placeholder.svg
+++ b/frontend/src/assets/presenter-placeholder.svg
@@ -1,0 +1,5 @@
+<svg width="50" height="50" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0.5" y="0.5" width="49" height="49" rx="6" ry="6" fill="white" stroke="#ccc" stroke-width="1"/>
+  <path d="M25 15c3.5 0 6 2.5 6 6s-2.5 6-6 6-6-2.5-6-6 2.5-6 6-6zm0 14c5.5 0 10 3 10 6v2H15v-2c0-3 4.5-6 10-6z"
+        fill="none" stroke="#999" stroke-width="1"/>
+</svg>

--- a/frontend/src/features/registration/PresenterPhotoField.tsx
+++ b/frontend/src/features/registration/PresenterPhotoField.tsx
@@ -14,6 +14,7 @@ import clsx from 'clsx';
 import {Button, Label, Message} from '@/components/ui';
 import type {FormField} from '@/data/registrationFormData';
 import { useAppConfig } from '@/hooks/useAppConfig';
+import presenterPlaceholder from '@/assets/presenter-placeholder.svg';
 import {uploadPresenterPhoto} from './presenterPhotoApi';
 
 const ACCEPTED_TYPES = 'image/png,image/jpeg,image/webp';
@@ -93,6 +94,9 @@ export function PresenterPhotoField({ field, value, onChange, isMissing, error }
         setCacheBuster(Date.now());
     }, [onChange]);
 
+    const previewSrc = imageSrc ?? presenterPlaceholder;
+    const previewAlt = imageSrc ? 'Presenter photo preview' : 'Default presenter placeholder';
+
     return (
         <div className="flex flex-col gap-1" aria-live="polite">
             <Label htmlFor={field.name}>
@@ -107,17 +111,16 @@ export function PresenterPhotoField({ field, value, onChange, isMissing, error }
                     )}
                     aria-hidden
                 >
-                    {imageSrc ? (
-                        <img
-                            src={imageSrc}
-                            alt="Presenter photo preview"
-                            className="h-full w-full rounded object-cover"
-                            width={MAX_PREVIEW_SIZE}
-                            height={MAX_PREVIEW_SIZE}
-                        />
-                    ) : (
-                        <span className="leading-tight text-red-700">No<br/>Photo</span>
-                    )}
+                    <img
+                        src={previewSrc}
+                        alt={previewAlt}
+                        className={clsx(
+                            'h-full w-full rounded',
+                            imageSrc ? 'object-cover' : 'object-contain'
+                        )}
+                        width={MAX_PREVIEW_SIZE}
+                        height={MAX_PREVIEW_SIZE}
+                    />
                 </div>
                 <div className="flex flex-col gap-2">
                     <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- add an SVG placeholder asset for presenter photos
- update the presenter photo field to display the placeholder when no custom image is available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1d80373688322808d05fee16544fd