### PR TITLE
Refine admin privilege handling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import HomePage from './features/home/HomePage';
 import AdministrationPage from './features/administration/AdministrationPage';
 import AppLayout from '@/components/layout/AppLayout';
 import { AuthProvider, useAuth } from './features/auth/AuthContext';
+import { hasAdminPrivileges } from './features/auth/adminPrivileges';
 
 type LoginSuccessPayload = {
     registration?: any;
@@ -24,7 +25,7 @@ const AppRoutes: React.FC = () => {
 
             login(registration);
 
-            const target = registration.isOrganizer ? '/organizer' : '/register';
+            const target = hasAdminPrivileges(registration) ? '/organizer' : '/register';
             navigate(target, { state: { registration } });
         },
         [login, navigate],

--- a/frontend/src/components/ui/AdminTabs.tsx
+++ b/frontend/src/components/ui/AdminTabs.tsx
@@ -5,12 +5,12 @@ import { useAuth } from '@/features/auth/AuthContext';
 import TabsBar from './TabsBar';
 
 type AdminTabsProps = {
-    activeTab: 'list' | 'update';
-    onSelect: (tab: 'list' | 'update') => void;
-    canViewList?: boolean;
+    activeTab: 'list' | 'update' | 'presenters';
+    onSelect: (tab: 'list' | 'update' | 'presenters') => void;
+    isAdmin?: boolean;
 };
 
-const AdminTabs: React.FC<AdminTabsProps> = ({ activeTab, onSelect, canViewList = true }) => {
+const AdminTabs: React.FC<AdminTabsProps> = ({ activeTab, onSelect, isAdmin = true }) => {
     const navigate = useNavigate();
     const { registration, logout } = useAuth();
     const [loggingOut, setLoggingOut] = useState(false);
@@ -31,6 +31,7 @@ const AdminTabs: React.FC<AdminTabsProps> = ({ activeTab, onSelect, canViewList 
     const handleHome = useCallback(() => navigate('/home'), [navigate]);
     const handleForm = () => onSelect('update');
     const handleList = () => onSelect('list');
+    const handlePresenters = () => onSelect('presenters');
 
     const isLoggedIn = Boolean(registration);
     const homeLabel = isLoggedIn ? 'Logout' : 'Home';
@@ -53,13 +54,20 @@ const AdminTabs: React.FC<AdminTabsProps> = ({ activeTab, onSelect, canViewList 
         },
     ];
 
-    if (canViewList) {
+    if (isAdmin) {
         items.push({
             id: 'tab-list',
             label: 'Registrations Table',
             onClick: handleList,
             active: activeTab === 'list',
             ariaControls: 'tab-panel-list',
+        });
+        items.push({
+            id: 'tab-presenters',
+            label: 'Presenters',
+            onClick: handlePresenters,
+            active: activeTab === 'presenters',
+            ariaControls: 'tab-panel-presenters',
         });
     }
 

--- a/frontend/src/features/administration/components/PresentersTab.tsx
+++ b/frontend/src/features/administration/components/PresentersTab.tsx
@@ -1,0 +1,238 @@
+// frontend/src/features/administration/components/PresentersTab.tsx
+
+import React, { useMemo, useState, useCallback, useRef, useEffect } from "react";
+import { Copy } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import presenterPlaceholder from "@/assets/presenter-placeholder.svg";
+import type { Registration } from "../types";
+import { formatFullName } from "../utils/formatName";
+
+type PresentersTabProps = {
+    presenters: Registration[];
+    isLoading: boolean;
+    error: string | null;
+};
+
+type CopyButtonProps = {
+    text: string;
+    label: string;
+};
+
+const CopyButton: React.FC<CopyButtonProps> = ({ text, label }) => {
+    const [copied, setCopied] = useState(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (timeoutRef.current != null) {
+                clearTimeout(timeoutRef.current);
+                timeoutRef.current = null;
+            }
+        };
+    }, []);
+
+    const fallbackCopy = useCallback((value: string) => {
+        if (typeof document === "undefined") return;
+        const textarea = document.createElement("textarea");
+        textarea.value = value;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "absolute";
+        textarea.style.left = "-9999px";
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            document.execCommand("copy");
+        } catch {
+            // Ignore failure; we gave it our best shot.
+        }
+        document.body.removeChild(textarea);
+    }, []);
+
+    const handleCopy = useCallback(async () => {
+        const value = text.trim();
+        if (!value) return;
+
+        try {
+            if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+                await navigator.clipboard.writeText(value);
+            } else {
+                fallbackCopy(value);
+            }
+            setCopied(true);
+        } catch {
+            fallbackCopy(value);
+            setCopied(true);
+        }
+
+        if (timeoutRef.current != null) {
+            clearTimeout(timeoutRef.current);
+        }
+        if (typeof window !== "undefined") {
+            timeoutRef.current = window.setTimeout(() => {
+                setCopied(false);
+                timeoutRef.current = null;
+            }, 1500);
+        }
+    }, [fallbackCopy, text]);
+
+    if (!text || !text.trim()) return null;
+
+    return (
+        <button
+            type="button"
+            onClick={handleCopy}
+            aria-label={`Copy ${label}`}
+            title={copied ? "Copied" : `Copy ${label}`}
+            className={cn(
+                "inline-flex h-8 w-8 items-center justify-center rounded border border-border text-muted-foreground transition",
+                "hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                copied && "bg-muted text-foreground"
+            )}
+        >
+            <Copy className="h-4 w-4" aria-hidden="true" />
+        </button>
+    );
+};
+
+type CopyableFieldProps = {
+    label: string;
+    text?: string | null;
+    multiline?: boolean;
+    emphasize?: boolean;
+};
+
+const CopyableField: React.FC<CopyableFieldProps> = ({ label, text, multiline = false, emphasize = false }) => {
+    const value = (text ?? "").trim();
+    if (!value) return null;
+
+    return (
+        <div
+            className={cn(
+                "rounded-lg border border-border bg-background p-4 shadow-sm",
+                emphasize ? "bg-muted/50" : "bg-background"
+            )}
+        >
+            <div className="mb-2 flex items-start justify-between gap-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{label}</span>
+                <CopyButton text={value} label={label} />
+            </div>
+            <div className={cn("text-sm text-foreground", multiline && "whitespace-pre-line")}>{value}</div>
+        </div>
+    );
+};
+
+const CopyableLine: React.FC<CopyableFieldProps> = ({ label, text }) => {
+    const value = (text ?? "").trim();
+    if (!value) return null;
+
+    return (
+        <div className="flex items-start justify-between gap-2">
+            <div className="space-y-1">
+                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{label}</span>
+                <span className="text-sm text-foreground">{value}</span>
+            </div>
+            <CopyButton text={value} label={label} />
+        </div>
+    );
+};
+
+function buildPhotoSrc(path: unknown): string | null {
+    if (typeof path !== "string") return null;
+    const trimmed = path.trim();
+    if (!trimmed) return null;
+    const normalized = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
+    return `/media/${normalized}`;
+}
+
+const PresentersTab: React.FC<PresentersTabProps> = ({ presenters, isLoading, error }) => {
+    const sortedPresenters = useMemo(() => {
+        return [...presenters].sort((a, b) => {
+            const lastA = (a.lastName ?? "").toLocaleLowerCase();
+            const lastB = (b.lastName ?? "").toLocaleLowerCase();
+            if (lastA !== lastB) return lastA.localeCompare(lastB);
+            const firstA = (a.firstName ?? "").toLocaleLowerCase();
+            const firstB = (b.firstName ?? "").toLocaleLowerCase();
+            return firstA.localeCompare(firstB);
+        });
+    }, [presenters]);
+
+    const showLoading = isLoading;
+    const showError = Boolean(error);
+    const hasStatus = showLoading || showError;
+
+    if (!isLoading && !error && sortedPresenters.length === 0) {
+        return (
+            <div className="space-y-4">
+                {hasStatus && (
+                    <div className="space-y-2">
+                        {showLoading && <div className="text-sm text-muted-foreground">Loading presenters…</div>}
+                        {showError && <div className="text-sm text-red-600">Error: {error}</div>}
+                    </div>
+                )}
+                <div className="text-sm text-muted-foreground">No presenters found.</div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            {hasStatus && (
+                <div className="space-y-2">
+                    {showLoading && <div className="text-sm text-muted-foreground">Loading presenters…</div>}
+                    {showError && <div className="text-sm text-red-600">Error: {error}</div>}
+                </div>
+            )}
+            <div className="space-y-8">
+                {sortedPresenters.map((presenter) => {
+                    const fallbackName = presenter.email || `Presenter #${presenter.id}`;
+                    const name = formatFullName({
+                        namePrefix: presenter.namePrefix,
+                        firstName: presenter.firstName,
+                        lastName: presenter.lastName,
+                        nameSuffix: presenter.nameSuffix,
+                        fallback: fallbackName,
+                    });
+                    const photoSrc = buildPhotoSrc(presenter.presenterPicUrl) ?? presenterPlaceholder;
+                    const session2Title = (presenter.session2Title ?? "").trim();
+                    const session2Description = (presenter.session2Description ?? "").trim();
+                    const hasSecondSession = Boolean(session2Title || session2Description);
+
+                    return (
+                        <div key={presenter.id} className="space-y-4">
+                            <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+                                <div className="space-y-4">
+                                    <CopyableField label="Name" text={name} emphasize />
+                                    <CopyableLine label="Email" text={presenter.email} />
+                                    <CopyableField label="Presenter Bio" text={presenter.presenterBio} multiline />
+                                    <CopyableField label="Session Title" text={presenter.session1Title} />
+                                    <CopyableField label="Session Description" text={presenter.session1Description} multiline />
+                                    {hasSecondSession && (
+                                        <>
+                                            <CopyableField label="Session 2 Title" text={session2Title} />
+                                            <CopyableField label="Session 2 Description" text={session2Description} multiline />
+                                        </>
+                                    )}
+                                </div>
+                                <div className="flex justify-end md:justify-start">
+                                    <img
+                                        src={photoSrc}
+                                        alt={name ? `${name} presenter photo` : "Presenter photo"}
+                                        className="h-[50px] w-[50px] rounded object-cover md:h-[500px] md:w-[500px]"
+                                        width={500}
+                                        height={500}
+                                        loading="lazy"
+                                        decoding="async"
+                                    />
+                                </div>
+                            </div>
+                            <hr className="border-border" />
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};
+
+export default PresentersTab;

--- a/frontend/src/features/administration/utils/formatName.ts
+++ b/frontend/src/features/administration/utils/formatName.ts
@@ -1,0 +1,25 @@
+// frontend/src/features/administration/utils/formatName.ts
+
+export type NameParts = {
+    namePrefix?: string | null;
+    firstName?: string | null;
+    lastName?: string | null;
+    nameSuffix?: string | null;
+    fallback?: string | null;
+};
+
+export function formatFullName({
+    namePrefix,
+    firstName,
+    lastName,
+    nameSuffix,
+    fallback,
+}: NameParts): string {
+    const parts = [namePrefix, firstName, lastName, nameSuffix]
+        .map((part) => (part ?? "").trim())
+        .filter((part) => part.length > 0);
+
+    const combined = parts.join(" ");
+    const fallbackValue = (fallback ?? "").trim();
+    return combined || fallbackValue;
+}

--- a/frontend/src/features/auth/AuthContext.tsx
+++ b/frontend/src/features/auth/AuthContext.tsx
@@ -3,9 +3,12 @@
 import React, {createContext, useCallback, useContext, useEffect, useMemo, useState} from "react";
 import {apiFetch, clearCsrf} from "@/lib/api";
 
+import { hasAdminPrivileges } from "./adminPrivileges";
+
 export interface AuthContextValue {
     registration: Record<string, any> | null;
     isOrganizer: boolean;
+    isAdmin: boolean;
     loading: boolean;
     login: (registration: Record<string, any>) => void;
     logout: () => Promise<void>;
@@ -34,9 +37,14 @@ function persistRegistration(registration: Record<string, any> | null) {
                 "regIsOrganizer",
                 registration.isOrganizer ? "true" : "false"
             );
+            sessionStorage.setItem(
+                "regIsAdmin",
+                hasAdminPrivileges(registration) ? "true" : "false"
+            );
         } else {
             sessionStorage.removeItem("regId");
             sessionStorage.removeItem("regIsOrganizer");
+            sessionStorage.removeItem("regIsAdmin");
         }
     } catch {
         // Ignore storage errors (e.g., Safari private mode)
@@ -102,6 +110,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         () => ({
             registration,
             isOrganizer: Boolean(registration?.isOrganizer),
+            isAdmin: hasAdminPrivileges(registration),
             loading,
             login,
             logout,

--- a/frontend/src/features/auth/adminPrivileges.ts
+++ b/frontend/src/features/auth/adminPrivileges.ts
@@ -1,0 +1,13 @@
+export const ADMIN_PRIVILEGE_FLAGS = ["isOrganizer", "isMonitor"] as const;
+
+type RegistrationLike = Record<string, any> | null | undefined;
+
+type AdminFlag = (typeof ADMIN_PRIVILEGE_FLAGS)[number];
+
+type WithOptionalFlag = Partial<Record<AdminFlag, unknown>> & Record<string, any>;
+
+export function hasAdminPrivileges(registration: RegistrationLike): boolean {
+    if (!registration) return false;
+    const candidate = registration as WithOptionalFlag;
+    return ADMIN_PRIVILEGE_FLAGS.some((flag) => Boolean(candidate[flag]));
+}


### PR DESCRIPTION
## Summary
- add a shared helper to detect admin-privileged registrations from role flags
- expose an `isAdmin` flag from the auth context and persist it in session storage
- gate administration navigation and presenters access on the unified admin flag

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2c35fbf4c83229e06f6dcd8ff6ae0