### PR TITLE
Hide second session fields until presenter opts in

### DIFF
--- a/frontend/src/features/registration/RegistrationForm.tsx
+++ b/frontend/src/features/registration/RegistrationForm.tsx
@@ -191,6 +191,18 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({
             });
         }
 
+        if (name === "isSecondSession" && !checked) {
+            const secondSessionFields = ["session2Title", "session2Description"] as const;
+            secondSessionFields.forEach((field) => {
+                clearMissing(field);
+                dispatch({ type: "CHANGE_FIELD", name: field, value: "" });
+                setErrors((prev) => {
+                    const { [field]: _removed, ...rest } = prev;
+                    return rest;
+                });
+            });
+        }
+
         dispatch({ type: 'CHANGE_FIELD', name, value: checked });
     };
 

--- a/frontend/src/features/registration/formRules.ts
+++ b/frontend/src/features/registration/formRules.ts
@@ -109,6 +109,12 @@ export function canSeeField(
         (PRESENTER_FIELDS_SET.has(field.name) || (field.type === 'section' && field.name === 'presenter'))
     )
         return false;
+
+    if (
+        PRESENTER_REQUIRED_SECOND_SESSION_FIELDS.has(field.name) &&
+        (!isPresenter || !asBoolean(state.isSecondSession))
+    )
+        return false;
     if (field.scope === 'admin' && !hasUpdatePrivilege) return false;
 
     return true;


### PR DESCRIPTION
## Summary
- hide the presenter second session title and description fields unless the presenter opts into a second session
- clear the second session values and missing/error state when the presenter opts out

## Testing
- npm run test:ci *(fails: backend Vitest suite cannot resolve @ path aliases)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e3a149f48322a81939fdb31f7058