### PR TITLE
Move logout action to the end of the admin tab bar

### DIFF
--- a/frontend/src/components/ui/AdminTabs.tsx
+++ b/frontend/src/components/ui/AdminTabs.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { LogOut } from 'lucide-react';
 
 import { useAuth } from '@/features/auth/AuthContext';
 import TabsBar from './TabsBar';
@@ -37,14 +38,17 @@ const AdminTabs: React.FC<AdminTabsProps> = ({ activeTab, onSelect, isAdmin = tr
     const homeLabel = isLoggedIn ? 'Logout' : 'Home';
     const handlePrimary = isLoggedIn ? handleLogout : handleHome;
 
+    const primaryText = loggingOut ? 'Logging out…' : homeLabel;
+    const primaryLabel = isLoggedIn ? (
+        <span className="flex items-center gap-2">
+            <LogOut className="h-4 w-4" aria-hidden="true" />
+            <span>{primaryText}</span>
+        </span>
+    ) : (
+        primaryText
+    );
+
     const items = [
-        {
-            id: 'admin-primary',
-            label: loggingOut ? 'Logging out…' : homeLabel,
-            onClick: handlePrimary,
-            disabled: loggingOut,
-            type: 'action' as const,
-        },
         {
             id: 'tab-update',
             label: 'Registration Form',
@@ -70,6 +74,15 @@ const AdminTabs: React.FC<AdminTabsProps> = ({ activeTab, onSelect, isAdmin = tr
             ariaControls: 'tab-panel-presenters',
         });
     }
+
+    items.push({
+        id: 'admin-primary',
+        label: primaryLabel,
+        onClick: handlePrimary,
+        disabled: loggingOut,
+        type: 'action' as const,
+        className: 'ml-auto',
+    });
 
     return <TabsBar items={items} ariaLabel="Administration tabs" />;
 };

--- a/frontend/src/components/ui/TabsBar.tsx
+++ b/frontend/src/components/ui/TabsBar.tsx
@@ -38,7 +38,7 @@ const TabsBar: React.FC<TabsBarProps> = ({
     innerClassName,
 }) => {
     const containerClasses = cn('w-full border-b bg-card', sticky && 'sticky top-0 z-40', className);
-    const innerClasses = cn('mx-auto w-[98vw] px-4 py-2 sm:px-6', innerClassName);
+    const innerClasses = cn('mx-auto w-full px-4 py-2 sm:px-6', innerClassName);
 
     return (
         <div className={containerClasses}>


### PR DESCRIPTION
## Summary
- move the logout action to the end of the admin tab list and add the lucide logout icon when signed in
- keep the tab bar underline within the container width by updating the inner wrapper sizing

## Testing
- npm run test *(fails: vitest cannot resolve backend @/... aliases in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fe6030fc832291e32e8e601fbee5