### PR TITLE
Add RSVP tracking column and PIN email option

### DIFF
--- a/backend/drizzle/migrations/0004_loyal_gryphon.sql
+++ b/backend/drizzle/migrations/0004_loyal_gryphon.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `registrations` ADD `has_rsvp` boolean DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX `idx_has_rsvp` ON `registrations` (`has_rsvp`);

--- a/backend/drizzle/migrations/meta/_journal.json
+++ b/backend/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1755406956618,
       "tag": "0003_hesitant_wendigo",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1756692827000,
+      "tag": "0004_loyal_gryphon",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -66,6 +66,7 @@ export const registrations = mysqlTable('registrations', {
     isPresenter: boolean('is_presenter').default(false),
     isSponsor: boolean('is_sponsor').default(false),
     hasProxy: boolean('has_proxy').default(false),
+    hasRsvp: boolean('has_rsvp').default(false),
 
 }, (table) => ({
     emailIdx: uniqueIndex('idx_registrations_email').on(table.email),
@@ -76,6 +77,7 @@ export const registrations = mysqlTable('registrations', {
     isPresenterIdx: index('idx_is_presenter').on(table.isPresenter),
     isSponsorIdx: index('idx_is_sponsor').on(table.isSponsor),
     hasProxyIdx: index('idx_has_proxy').on(table.hasProxy),
+    hasRsvpIdx: index('idx_has_rsvp').on(table.hasRsvp),
 }));
 
 export const credentials = mysqlTable('credentials', {

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -1,10 +1,11 @@
 // frontend/src/features/home/HomePage.tsx
 
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Message } from '@/components/ui/message';
+import { Checkbox } from '@/components/ui/checkbox';
 import { isValidEmail } from '../registration/formRules';
 import { apiFetch, saveCsrf } from '@/lib/api';
 
@@ -19,11 +20,14 @@ const HomePage: React.FC<HomePageProps> = ({ onSuccess }) => {
     const [pin, setPin] = useState('');
     const [emailError, setEmailError] = useState('');
     const [submitting, setSubmitting] = useState(false);
+    const [emailMyPin, setEmailMyPin] = useState(false);
+    const [status, setStatus] = useState<{ text: string; isError?: boolean } | null>(null);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        if (submitting) return;
+        if (submitting || emailMyPin) return;
         setSubmitting(true);
+        setStatus(null);
 
         try {
             const data = await apiFetch('/api/registrations/login', {
@@ -48,13 +52,56 @@ const HomePage: React.FC<HomePageProps> = ({ onSuccess }) => {
         }
     };
 
+    const handleEmailMyPinChange = useCallback(
+        async (nextChecked: boolean) => {
+            if (submitting) return;
+
+            if (!nextChecked) {
+                setEmailMyPin(false);
+                return;
+            }
+
+            if (!isValidEmail(email)) {
+                const warning = 'Please enter your email address to receive your PIN.';
+                setEmailError(warning);
+                setStatus({ text: warning, isError: true });
+                setEmailMyPin(false);
+                return;
+            }
+
+            setEmailError('');
+            setStatus(null);
+            setEmailMyPin(true);
+            setSubmitting(true);
+
+            try {
+                await apiFetch(`/api/registrations/lost-pin?email=${encodeURIComponent(email)}`);
+                setStatus({ text: 'Check your email in a few minutes.' });
+            } catch (err: any) {
+                const msg =
+                    (err?.data?.error as string) ||
+                    (typeof err?.message === 'string' ? err.message : 'Unable to send PIN email.');
+                setStatus({ text: msg, isError: true });
+            } finally {
+                setSubmitting(false);
+                setEmailMyPin(false);
+                setPin('');
+            }
+        },
+        [email, submitting]
+    );
+
     const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
         setEmail(value);
         setEmailError(value && !isValidEmail(value) ? 'Invalid email address' : '');
+        if (status?.isError) {
+            setStatus(null);
+        }
     };
 
-    const canSubmit = isValidEmail(email) && pin.trim() !== '' && !submitting;
+    const canSubmit = isValidEmail(email) && pin.trim() !== '' && !submitting && !emailMyPin;
+    const submitLabel = submitting ? (emailMyPin ? 'Sending…' : 'Signing in…') : 'Sign in';
 
     return (
         <div className="space-y-6">
@@ -80,30 +127,48 @@ const HomePage: React.FC<HomePageProps> = ({ onSuccess }) => {
                     {emailError && <Message id="email-error" text={emailError} isError />}
                 </div>
 
-                <div className="flex flex-col gap-1">
-                    <Label htmlFor="pin">
-                        PIN<sup className="text-red-500">*</sup>
-                    </Label>
-                    <Input
-                        id="pin"
-                        type="password"
-                        value={pin}
-                        onChange={(e) => setPin(e.target.value)}
-                        required
-                        autoComplete="one-time-code"
-                        inputMode="numeric"
+                {!emailMyPin && (
+                    <div className="flex flex-col gap-1">
+                        <Label htmlFor="pin">
+                            PIN<sup className="text-red-500">*</sup>
+                        </Label>
+                        <Input
+                            id="pin"
+                            type="password"
+                            value={pin}
+                            onChange={(e) => setPin(e.target.value)}
+                            required
+                            autoComplete="one-time-code"
+                            inputMode="numeric"
+                        />
+                    </div>
+                )}
+
+                <div className="flex items-center gap-2">
+                    <Checkbox
+                        id="email-my-pin"
+                        checked={emailMyPin}
+                        onCheckedChange={(checked) => {
+                            void handleEmailMyPinChange(Boolean(checked));
+                        }}
+                        disabled={submitting}
                     />
+                    <Label htmlFor="email-my-pin" className="text-sm">
+                        Email my pin
+                    </Label>
                 </div>
 
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
                     <Button type="submit" disabled={!canSubmit}>
-                        {submitting ? 'Signing in…' : 'Sign in'}
+                        {submitLabel}
                     </Button>
                     <p className="text-xs text-muted-foreground sm:text-sm">
                         Need help? Contact your conference organizer for assistance.
                     </p>
                 </div>
             </form>
+
+            {status && <Message text={status.text} isError={status.isError} />}
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- add a has_rsvp column and index via a new migration and update the schema
- automatically mark registrations as having an RSVP after updates and expose both RSVP flags in API responses
- surface RSVP filter pills in the admin list and add a "Email my pin" helper flow on the login page

## Testing
- npm run typecheck:app
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54f69784083229b5a247c3da82c7f