### PR TITLE
Set active registration filter background to dark brown

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -151,7 +151,14 @@ hr {
     .admin-filter-pill { @apply whitespace-nowrap rounded-full px-3 py-1 text-sm; }
     .admin-filter-pill--inactive { @apply border-neutral-300 text-neutral-700 hover:bg-amber-50; }
     .admin-filter-pill--active {
-        @apply bg-[#4b2e17] text-white border-[#4b2e17] hover:bg-[#3a2311] hover:text-white;
+        background-color: #4b2e17 !important;
+        border-color: #4b2e17 !important;
+        color: #ffffff !important;
+    }
+
+    .admin-filter-pill--active:hover {
+        background-color: #3a2311 !important;
+        color: #ffffff !important;
     }
 
     /* Toolbar layout */


### PR DESCRIPTION
## Summary
- ensure active registration filter pills use a dark brown background and text color overrides
- add explicit hover styling to keep the button dark when active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e71ab936408322916d7a9d42b29947