### PR TITLE
Add Has RSVP checkbox to admin roles section

### DIFF
--- a/frontend/src/data/registrationFormData.ts
+++ b/frontend/src/data/registrationFormData.ts
@@ -306,4 +306,12 @@ export const registrationFormData: FormField[] = [
         scope: 'admin',
         clickedByDefault: true,
     },
+    {
+        name: 'hasRSVP',
+        label: 'Has RSVP',
+        type: 'checkbox',
+        required: false,
+        scope: 'admin',
+        clickedByDefault: true,
+    },
 ];


### PR DESCRIPTION
## Summary
- add a Has RSVP checkbox field to the admin-only attendee roles section of the registration form data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e72ba331908322bb7cd5c1cecbf184