### PR TITLE
Update RSVP upload role codes to use organizer O

### DIFF
--- a/backend/src/routes/rsvp.ts
+++ b/backend/src/routes/rsvp.ts
@@ -136,9 +136,9 @@ function looksLikeHeader(row: CsvRow): boolean {
 function normalizeRole(raw: string): { isOrganizer: boolean; isPresenter: boolean } | null {
   const value = raw.trim().toUpperCase();
   if (!value) return { isOrganizer: false, isPresenter: false };
-  if (value === "A") return { isOrganizer: true, isPresenter: false };
+  if (value === "O") return { isOrganizer: true, isPresenter: false };
   if (value === "P") return { isOrganizer: false, isPresenter: true };
-  if (value === "AP" || value === "PA") return { isOrganizer: true, isPresenter: true };
+  if (value === "OP" || value === "PO") return { isOrganizer: true, isPresenter: true };
   return null;
 }
 

--- a/frontend/src/features/administration/components/RsvpUploadTab.tsx
+++ b/frontend/src/features/administration/components/RsvpUploadTab.tsx
@@ -35,9 +35,9 @@ const EmailSummaryDetails: React.FC<{ summary: EmailSummary }> = ({ summary }) =
 
 const ROLE_DESCRIPTIONS: Record<string, string> = {
     "": "Attendee only",
-    A: "Attendee & organizer",
+    O: "Attendee & organizer",
     P: "Attendee & presenter",
-    AP: "Attendee, presenter & organizer",
+    OP: "Attendee, presenter & organizer",
 };
 
 const RsvpUploadTab: React.FC = () => {
@@ -153,7 +153,7 @@ const RsvpUploadTab: React.FC = () => {
                     <strong> roles</strong>.
                 </p>
                 <p className="text-sm text-muted-foreground">
-                    Accepted role values are blank, A, P, or AP. The first row will be ignored when it looks like a header.
+                    Accepted role values are blank, O, P, or OP. The first row will be ignored when it looks like a header.
                 </p>
                 <div className="rounded-md border border-border bg-muted/30 p-3 text-xs text-muted-foreground">
                     <div className="font-medium text-foreground">Role designations</div>


### PR DESCRIPTION
## Summary
- adjust RSVP upload role normalization so organizer codes use O/OP instead of A/AP
- refresh the admin RSVP upload instructions to document the new role codes

## Testing
- npm --prefix backend test (no test files found)


------
https://chatgpt.com/codex/tasks/task_e_68eac18c2ff08322825c0bfba1b33692