### PR TITLE
Update RSVP reminder selection logic

### DIFF
--- a/backend/src/routes/rsvp.ts
+++ b/backend/src/routes/rsvp.ts
@@ -7,7 +7,7 @@ import { generatePin, isValidEmail } from "./registration.utils";
 import { getRegistrationByEmail } from "./registration.service";
 import { db } from "@/db/client";
 import { credentials, registrations } from "@/db/schema";
-import { eq, isNull, or } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { sql } from "drizzle-orm/sql";
 import { sendEmail } from "@/utils/email";
 import { fillRsvpTemplate, loadRsvpTemplate } from "@/utils/emailTemplates";
@@ -398,7 +398,7 @@ router.post("/remind", requireAuth, organizerOnly, async (req: Request, res: Res
       })
       .from(registrations)
       .innerJoin(credentials, eq(credentials.registrationId, registrations.id))
-      .where(or(isNull(registrations.lastName), eq(registrations.lastName, "")));
+      .where(eq(registrations.hasRsvp, false));
   } catch (err) {
     log.error("Failed to load pending RSVP reminders", { err });
     sendError(res, 500, "Failed to load pending RSVPs");


### PR DESCRIPTION
## Summary
- update the RSVP reminder query to target registrations without a recorded RSVP

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eac7fe77488322bef1130d22a2b03f