### PR TITLE
Fix RSVP column display in registration list

### DIFF
--- a/frontend/src/data/registrationFormData.ts
+++ b/frontend/src/data/registrationFormData.ts
@@ -316,7 +316,7 @@ export const registrationFormData: FormField[] = [
         hasFilterButton: true,
     },
     {
-        name: 'hasRSVP',
+        name: 'hasRsvp',
         label: 'Has RSVP',
         type: 'checkbox',
         required: false,

--- a/frontend/src/features/administration/AdministrationPage.tsx
+++ b/frontend/src/features/administration/AdministrationPage.tsx
@@ -178,7 +178,7 @@ const AdministrationPage: React.FC = () => {
                 const name = field.name;
                 if (!name) return;
 
-                if (name === "hasRSVP") {
+                if (name === "hasRsvp") {
                     if (!seenLabels.has("Has RSVP")) {
                         configs.push({ name: "hasRsvp", label: "Has RSVP", exclusiveWith: "hasNoRsvp" });
                         seenLabels.add("Has RSVP");
@@ -204,7 +204,10 @@ const AdministrationPage: React.FC = () => {
             {
                 accessorKey: "hasRsvp",
                 header: "Has RSVP",
-                cell: ({ getValue }) => (getValue<boolean>() ? "Yes" : "No"),
+                cell: ({ getValue }) => {
+                    const value = getValue<boolean | string | number>();
+                    return value == null ? "" : String(value);
+                },
                 enableColumnFilter: true,
                 filterFn: boolFilterFn,
                 meta: { clickedByDefault: false },
@@ -212,7 +215,10 @@ const AdministrationPage: React.FC = () => {
             {
                 accessorKey: "hasNoRsvp",
                 header: "No RSVP",
-                cell: ({ getValue }) => (getValue<boolean>() ? "Yes" : "No"),
+                cell: ({ getValue }) => {
+                    const value = getValue<boolean | string | number>();
+                    return value == null ? "" : String(value);
+                },
                 enableColumnFilter: true,
                 filterFn: boolFilterFn,
                 meta: { clickedByDefault: false },

--- a/frontend/src/features/administration/table/columns.ts
+++ b/frontend/src/features/administration/table/columns.ts
@@ -41,10 +41,13 @@ export function buildListColumnsFromForm<T extends RegistrationIndexable>(
         })
         .map((f) => {
             const name = f.name as string;
+            const headerLabel = typeof f.label === "string" && f.label.trim() !== ""
+                ? f.label
+                : camelToTitleCase(name);
 
             return {
                 accessorKey: name,
-                header: camelToTitleCase(name),
+                header: headerLabel,
                 cell: ({ getValue }) => {
                     const v = getValue<any>();
                     return v == null ? "" : String(v);


### PR DESCRIPTION
## Summary
- align the RSVP form field name with the API's `hasRsvp` property so table lookups find the data
- render registration column headers using field labels to preserve acronyms such as RSVP
- show raw boolean values in the RSVP columns instead of leaving them blank

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eaca06e0388322be039ce442311b54