### PR TITLE
Restore Has RSVP column visibility

### DIFF
--- a/frontend/src/data/registrationFormData.ts
+++ b/frontend/src/data/registrationFormData.ts
@@ -316,7 +316,7 @@ export const registrationFormData: FormField[] = [
         hasFilterButton: true,
     },
     {
-        name: 'hasRSVP',
+        name: 'hasRsvp',
         label: 'Has RSVP',
         type: 'checkbox',
         required: false,

--- a/frontend/src/features/administration/AdministrationPage.tsx
+++ b/frontend/src/features/administration/AdministrationPage.tsx
@@ -157,15 +157,17 @@ const AdministrationPage: React.FC = () => {
     }, []);
 
     const dynamicCols = useMemo<ColumnDef<Registration>[]>(() => {
-        return dynamicColsBase.map((col) => {
-            const key = getAccessorKey(col);
-            if (!key || !filterableFieldSet.has(key)) return col;
-            return {
-                ...col,
-                enableColumnFilter: true,
-                filterFn: boolFilterFn,
-            } as ColumnDef<Registration>;
-        });
+        return dynamicColsBase
+            .filter((col) => getAccessorKey(col) !== "hasRsvp")
+            .map((col) => {
+                const key = getAccessorKey(col);
+                if (!key || !filterableFieldSet.has(key)) return col;
+                return {
+                    ...col,
+                    enableColumnFilter: true,
+                    filterFn: boolFilterFn,
+                } as ColumnDef<Registration>;
+            });
     }, [dynamicColsBase, filterableFieldSet, boolFilterFn]);
 
     const filterToggleConfigs = useMemo<FilterToggleConfig[]>(() => {
@@ -178,7 +180,7 @@ const AdministrationPage: React.FC = () => {
                 const name = field.name;
                 if (!name) return;
 
-                if (name === "hasRSVP") {
+                if (name === "hasRsvp") {
                     if (!seenLabels.has("Has RSVP")) {
                         configs.push({ name: "hasRsvp", label: "Has RSVP", exclusiveWith: "hasNoRsvp" });
                         seenLabels.add("Has RSVP");
@@ -204,15 +206,21 @@ const AdministrationPage: React.FC = () => {
             {
                 accessorKey: "hasRsvp",
                 header: "Has RSVP",
-                cell: ({ getValue }) => (getValue<boolean>() ? "Yes" : "No"),
+                cell: ({ getValue }) => {
+                    const value = getValue<boolean | string | number>();
+                    return value == null ? "" : String(value);
+                },
                 enableColumnFilter: true,
                 filterFn: boolFilterFn,
-                meta: { clickedByDefault: false },
+                meta: { clickedByDefault: true },
             },
             {
                 accessorKey: "hasNoRsvp",
                 header: "No RSVP",
-                cell: ({ getValue }) => (getValue<boolean>() ? "Yes" : "No"),
+                cell: ({ getValue }) => {
+                    const value = getValue<boolean | string | number>();
+                    return value == null ? "" : String(value);
+                },
                 enableColumnFilter: true,
                 filterFn: boolFilterFn,
                 meta: { clickedByDefault: false },

--- a/frontend/src/features/administration/table/columns.ts
+++ b/frontend/src/features/administration/table/columns.ts
@@ -41,10 +41,13 @@ export function buildListColumnsFromForm<T extends RegistrationIndexable>(
         })
         .map((f) => {
             const name = f.name as string;
+            const headerLabel = typeof f.label === "string" && f.label.trim() !== ""
+                ? f.label
+                : camelToTitleCase(name);
 
             return {
                 accessorKey: name,
-                header: camelToTitleCase(name),
+                header: headerLabel,
                 cell: ({ getValue }) => {
                     const v = getValue<any>();
                     return v == null ? "" : String(v);


### PR DESCRIPTION
## Summary
- prevent the dynamically generated registration columns from duplicating the Has RSVP field so the custom version can render
- default the Has RSVP admin column to visible again while keeping the boolean string rendering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eaca06e0388322be039ce442311b54