### PR TITLE
Strip parenthetical hints from registration column labels

### DIFF
--- a/frontend/src/features/administration/table/columns.ts
+++ b/frontend/src/features/administration/table/columns.ts
@@ -41,9 +41,19 @@ export function buildListColumnsFromForm<T extends RegistrationIndexable>(
         })
         .map((f) => {
             const name = f.name as string;
-            const headerLabel = typeof f.label === "string" && f.label.trim() !== ""
-                ? f.label
-                : camelToTitleCase(name);
+            let headerLabel: string | undefined;
+
+            if (typeof f.label === "string") {
+                const trimmedLabel = f.label.trim();
+                if (trimmedLabel !== "") {
+                    const withoutParenText = trimmedLabel.replace(/\s*\([^()]*\)/g, "").trim();
+                    headerLabel = withoutParenText !== "" ? withoutParenText : undefined;
+                }
+            }
+
+            if (!headerLabel) {
+                headerLabel = camelToTitleCase(name);
+            }
 
             return {
                 accessorKey: name,


### PR DESCRIPTION
## Summary
- remove parenthetical helper text from dynamically generated registration table column headers
- fall back to camel-cased titles when labels become empty after cleanup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ead12a5fe083228652ff47b52bd49b