### PR TITLE
Add presenters filter for two-session presenters

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -150,6 +150,9 @@ hr {
     /* Filter pills */
     .admin-filter-pill { @apply whitespace-nowrap rounded-full px-3 py-1 text-sm; }
     .admin-filter-pill--inactive { @apply border-neutral-300 text-neutral-700 hover:bg-amber-50; }
+    .admin-filter-pill--disabled {
+        @apply border-neutral-200 bg-neutral-100 text-neutral-400 hover:bg-neutral-100;
+    }
     .admin-filter-pill--active {
         background-color: #4b2e17 !important;
         border-color: #4b2e17 !important;


### PR DESCRIPTION
## Summary
- replace the presenters tab "Missing Session Info" filter with a new "Has Two Sessions" filter that counts presenters with second sessions
- ensure the new filter disables itself and shows a greyed style when no presenters qualify while keeping other presenter filtering behavior the same
- add styling for the disabled filter pill state to keep inactive filters visually muted

## Testing
- npm run lint *(fails: Missing script "lint" defined in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68eade5d8bfc83228e1584d47100b03e